### PR TITLE
Add alternative ISO2 codes used by the European Commission

### DIFF
--- a/region/README.md
+++ b/region/README.md
@@ -39,13 +39,17 @@ See [aggregate-regions.yaml](aggregate-regions.yaml) for the codelist.
 
 Each country in this list includes the ISO2 and ISO3 codes as an attribute
 as well as a flag on EU membership and (optional) a list of synonyms.
+The list also includes the alternatives to the *ISO 3166-1 alpha-2 standard*
+used by the [European Commission](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)
+(`iso2_alt`).
 
 See [countries.yaml](countries.yaml) for the codelist.
 
 #### Example for using this codelist
 
 The code snippet (Python) below shows how to obtain the list of countries
-and a mapping of ISO2-codes to the common country names.
+and a mapping of ISO2-codes (including alternatives)
+to the common country names.
 
 ```python
 import yaml
@@ -53,8 +57,12 @@ with open('countries.yaml', 'r') as stream:
     country_mapping = yaml.load(stream, Loader=yaml.FullLoader)
 
 list_of_countries = list(country_mapping.keys())
-iso2_mapping = dict([(country_mapping[c]['iso2'], c)
-                     for c in country_mapping.keys()])
+iso2_mapping = dict(
+    [(country_mapping[c]['iso2'], c) for c in country_mapping]
+    # add alternative iso2 codes used by the European Commission to the mapping
+    + [(country_mapping[c]['iso2_alt'], c) for c in country_mapping
+       if 'iso2_alt' in country_mapping[c]]
+)
 ```
 
 ### Sub-country areas

--- a/region/countries.yaml
+++ b/region/countries.yaml
@@ -85,6 +85,7 @@ Gibraltar:
 
 Greece:
    iso2: 'GR'
+   iso2_alt: 'EL' # the European Commission uses alternative ISO2 codes
    iso3: 'GRC'
    eu_member: True
 
@@ -231,6 +232,7 @@ Ukraine:
 
 United Kingdom:
    iso2: 'GB'
+   iso2_alt: 'UK' # the European Commission uses alternative ISO2 codes
    iso3: 'GBR'
    eu_member: False
    synonyms: ['Great Britain']

--- a/region/data/write-countries.py
+++ b/region/data/write-countries.py
@@ -13,10 +13,19 @@ file.writelines(f'# This file was created using the script `data/{this}`\n')
 file.write('# DO NOT ALTER THIS FILE MANUALLY!\n\n')
 file.write('# List of countries\n')
 
+# the EU uses alternative ISO2 codes for some countries
+iso2_alternatives = {
+    'GB': 'UK',
+    'GR': 'EL'
+}
+
 # write list of countries with dictionary of relevant information
 for i, (name, iso2, iso3, eu, syn) in countries.iterrows():
     file.write(f"\n{name}:\n")
     file.write(f"   iso2: '{iso2}'\n")
+    if iso2 in iso2_alternatives.keys():
+        file.write(f"   iso2_alt: '{iso2_alternatives[iso2]}'")
+        file.write(" # the European Commission uses alternative ISO2 codes\n")
     file.write(f"   iso3: '{iso3}'\n")
     file.write(f"   eu_member: {eu if eu is True else False}\n")
     if isinstance(syn, str):


### PR DESCRIPTION
This PR adds attributes for the alternative ISO2 codes used by the European Commission for the UK and Greece to the codelist (`countries.yaml`) and extends the Python snipped in the regions readme to include those alternatives in the ISO2 mapping. This makes it easier to translate EU documents (e.g., the NUTS classification table) to the common country names.