### PR TITLE
Adding specifications for sub-annual time resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,11 @@ In the data format, every timeseries is described by six dimensions (codes):
 3.	Region - [more information](region)
 4.	Variable - [more information](variable)
 5.	Unit - see the section on [variables](variable) for details
-6.	Subannual (optional, default 'Year')<sup>[1][2]</sup>
+6.	Subannual (optional, default 'Year')<sup>[1]</sup> -
+    [more information](subannual)
 
 [1] *The index 'Subannual' is an extension of the original format introduced by
 the openENTRANCE project to accomodate data at a subannual temporal resolution.*
-
-[2] *A detailed description of this dimensions and the shared terms
-(i.e., codelists) will be added soon!**
 
 ### Recommended usage of this data format
 

--- a/subannual/README.md
+++ b/subannual/README.md
@@ -6,7 +6,38 @@ The column is **not required**; if it is not provided,
 the timeseries is understood as yearly data.
 The default value for this column is 'Year'.
 
-*This column is an extension of the format as defined by the 
+*This column is an extension compared to the format as defined by the 
 [IAMC](http://www.globalchange.umd.edu/iamc/) and used in the context
 of IPCC Reports and other model comparison studies.
 These previous scenario ensembles only used yearly timeseries data.*
+
+## Overview
+
+The list of subannual "timeslices" are grouped into several categories
+and levels of temporal detail.
+Timeslices can be either understood as consecutive periods or as
+representative periods (e.g., "summer-day").
+
+Each item in the codelists below includes an attribute `duration` indicating
+the duration relative to a normal year (i.e., not a leap year).
+
+### Months
+
+See [months.yaml](months.yaml) for the codelist.
+
+#### Example for using this codelist
+
+The code snippet (Python) below shows how to obtain a mapping of months
+to their respective duration.
+
+```python
+import yaml
+with open(f'../subannual/months.yaml', 'r') as stream:
+    months = yaml.load(stream, Loader=yaml.FullLoader)
+
+mapping = dict([(m, eval(attr['duration'])) for (m, attr) in months.items()])
+```
+
+### Other categories
+
+*Other categories to be added over time*

--- a/subannual/README.md
+++ b/subannual/README.md
@@ -1,0 +1,12 @@
+# Guidelines for subannual data resolution
+
+The **subannual** column in the data format specifies the temporal scope
+of the timeseries data at a sub-annual resolution.
+The column is **not required**; if it is not provided,
+the timeseries is understood as yearly data.
+The default value for this column is 'Year'.
+
+*This column is an extension of the format as defined by the 
+[IAMC](http://www.globalchange.umd.edu/iamc/) and used in the context
+of IPCC Reports and other model comparison studies.
+These previous scenario ensembles only used yearly timeseries data.*

--- a/subannual/months.yaml
+++ b/subannual/months.yaml
@@ -1,0 +1,37 @@
+# List of months
+
+January:
+   duration: 31. / 365
+
+February:
+   duration: 28 / 365
+
+March:
+   duration: 31 / 365
+
+April:
+   duration: 30 / 365
+
+May:
+   duration: 31 / 365
+
+June:
+   duration: 30 / 365
+
+July:
+   duration: 30 / 365
+
+August:
+   duration: 31 / 365
+
+September:
+   duration: 30 / 365
+
+October:
+   duration: 31 / 365
+
+November:
+   duration: 30 / 365
+
+December:
+   duration: 31 / 365

--- a/subannual/months.yaml
+++ b/subannual/months.yaml
@@ -1,7 +1,7 @@
 # List of months
 
 January:
-   duration: 31. / 365
+   duration: 31 / 365
 
 February:
    duration: 28 / 365


### PR DESCRIPTION
This PR adds a subfolder for the sub-annual dimension of the data format, using the disaggregation level of "months" for defining a structure of README and yaml file.

closes #5