### PR TITLE
add explanation on year-value in the data format

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ In the data format, every timeseries is described by six dimensions (codes):
 6.	Subannual (optional, default 'Year')<sup>[1]</sup> -
     [more information](subannual)
 
+In addition to these six dimensions, every timeseries is described by
+a set of year-value pairs.
+The resulting table can be either shown in **wide format**
+(see example below, with *years* as columns)
+or in **long format** (two columns *year*  and *value*).
+
+| **model** | **scenario** | **region** | **variable**   | **unit** | **subannual** | **2005** | **2010** | **2015** |
+|-----------|--------------|------------|----------------|----------|---------------|---------:|---------:|---------:|
+| MESSAGE   | CD-LINKS 400 | World      | Primary Energy | EJ/y     | Year          |    462.5 |    500.7 |      ... |
+| ...       | ...          | ...        | ...            | ...      | ...           |      ... |      ... |      ... |
+
+<small>Data via the [IAMC 1.5°C scenario explorer](https://data.ene.iiasa.ac.at/iamc-1.5c-explorer),
+showing a scenario from the [CD-LINKS](https://www.cd-links.org) project.</small>
+
 [1] *The index 'Subannual' is an extension of the original format introduced by
 the openENTRANCE project to accomodate data at a subannual temporal resolution.*
 

--- a/README.md
+++ b/README.md
@@ -55,18 +55,18 @@ In the data format, every timeseries is described by six dimensions (codes):
     [more information](subannual)
 
 In addition to these six dimensions, every timeseries is described by
-a set of year-value pairs.
-The resulting table can be either shown in **wide format**
-(see example below, with *years* as columns)
-or in **long format** (two columns *year*  and *value*).
+a set of **year-value** pairs.
+
+The resulting table can be either shown as
+- **wide format** (see example below, with *years* as columns), or
+- **long format** (two columns *year*  and *value*).
 
 | **model** | **scenario** | **region** | **variable**   | **unit** | **subannual** | **2005** | **2010** | **2015** |
 |-----------|--------------|------------|----------------|----------|---------------|---------:|---------:|---------:|
 | MESSAGE   | CD-LINKS 400 | World      | Primary Energy | EJ/y     | Year          |    462.5 |    500.7 |      ... |
 | ...       | ...          | ...        | ...            | ...      | ...           |      ... |      ... |      ... |
 
-<small>Data via the [IAMC 1.5°C scenario explorer](https://data.ene.iiasa.ac.at/iamc-1.5c-explorer),
-showing a scenario from the [CD-LINKS](https://www.cd-links.org) project.</small>
+###### Data via the [IAMC 1.5°C scenario explorer](https://data.ene.iiasa.ac.at/iamc-1.5c-explorer), showing a scenario from the [CD-LINKS](https://www.cd-links.org) project.
 
 [1] *The index 'Subannual' is an extension of the original format introduced by
 the openENTRANCE project to accomodate data at a subannual temporal resolution.*

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ The resulting table can be either shown as
 | MESSAGE   | CD-LINKS 400 | World      | Primary Energy | EJ/y     | Year          |    462.5 |    500.7 |      ... |
 | ...       | ...          | ...        | ...            | ...      | ...           |      ... |      ... |      ... |
 
-###### Data via the [IAMC 1.5°C scenario explorer](https://data.ene.iiasa.ac.at/iamc-1.5c-explorer), showing a scenario from the [CD-LINKS](https://www.cd-links.org) project.
+<sup>Data via the [IAMC 1.5°C scenario explorer](https://data.ene.iiasa.ac.at/iamc-1.5c-explorer),
+    showing a scenario from the [CD-LINKS](https://www.cd-links.org) project.</sup>
 
 [1] *The index 'Subannual' is an extension of the original format introduced by
 the openENTRANCE project to accomodate data at a subannual temporal resolution.*


### PR DESCRIPTION
This PR adds a short explanation of the year-value components in the data format section of the top-level README.

Preview available [here](https://github.com/danielhuppmann/nomenclature/blob/structure/year-value/README.md)

closes #9