### PR TITLE
Add demand side flexibility potentials

### DIFF
--- a/variable/technology/technologies.yaml
+++ b/variable/technology/technologies.yaml
@@ -1095,4 +1095,4 @@ Rate Automatic Frequency Restoration Reserve|Electricity|Wind|OffShore:
 Load Shifting Potential|Electricity|Residential|AC:
    description: Maximum shiftable load in a given region/time frame,
                 due to households changing their air conditioning usage.
-   unit: 'MW'
+   unit: MW

--- a/variable/technology/technologies.yaml
+++ b/variable/technology/technologies.yaml
@@ -1089,3 +1089,30 @@ Rate Automatic Frequency Restoration Reserve|Electricity|Wind|OffShore:
    description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
                 for a Wind OffShore power plant
    unit: '%'
+   
+# description of Demand flexibility potentials
+Number of Units|Electricity|Residential|Demand Flexibility:
+   description: Number of units of kind "simple Hydro reservoir "
+   unit: 
+   
+Maximum Active power|Electricity|Residential|Demand Flexibility:
+   description: Potential for demand response in a given region/time frame, 
+                expressed as % decrease in residential electricity demand
+   unit: %
+   
+Maximum Storage|Electricity|Residential|Demand Flexibility:
+   description: Potential for demand dispatch in a given region/time frame,
+                expressed as % increase in residential electricity demand 
+   unit: %
+   
+Variable Cost|Electricity|Residential|Demand Flexibility:
+   description: Marginal cost of Demand Flexibility in residential electricity demand
+   unit: €/% change
+   
+Capital Cost|Electricity|Residential|Demand Flexibility|Maximum Active power:
+   description: Fixed costs associated with demand flexibility potentials (e.g. installing IoT devices)
+   unit: €/%
+   
+Capital Cost|Electricity|Residential|Demand Flexibility|Maximum Storage:
+   description: Fixed costs associated with demand flexibility potentials (e.g. installing IoT devices)
+   unit: €/%

--- a/variable/technology/technologies.yaml
+++ b/variable/technology/technologies.yaml
@@ -1092,7 +1092,7 @@ Rate Automatic Frequency Restoration Reserve|Electricity|Wind|OffShore:
    
 # description of Demand flexibility potentials
    
-Load Shifting Potential|Electricity|Residential|AC:
+Load Shifting Potential|Electricity|Residential|Air Conditioning:
    description: Maximum shiftable load in a given region/time frame,
                 due to households changing their air conditioning usage.
    unit: MW

--- a/variable/technology/technologies.yaml
+++ b/variable/technology/technologies.yaml
@@ -1091,28 +1091,27 @@ Rate Automatic Frequency Restoration Reserve|Electricity|Wind|OffShore:
    unit: '%'
    
 # description of Demand flexibility potentials
-Number of Units|Electricity|Residential|Demand Flexibility:
-   description: Number of units of kind "simple Hydro reservoir "
-   unit: 
    
 Maximum Active power|Electricity|Residential|Demand Flexibility:
    description: Potential for demand response in a given region/time frame, 
-                expressed as % decrease in residential electricity demand
-   unit: %
+                expressed as '%' decrease in residential electricity demand,
+                analogous to inputting power from a storage unit.
+   unit: '%'
    
 Maximum Storage|Electricity|Residential|Demand Flexibility:
    description: Potential for demand dispatch in a given region/time frame,
-                expressed as % increase in residential electricity demand 
-   unit: %
+                expressed as '%' increase in residential electricity demand,
+                analogous to drawing power into storage unit.
+   unit: '%'
    
 Variable Cost|Electricity|Residential|Demand Flexibility:
    description: Marginal cost of Demand Flexibility in residential electricity demand
-   unit: €/% change
+   unit: €/'%' change
    
 Capital Cost|Electricity|Residential|Demand Flexibility|Maximum Active power:
    description: Fixed costs associated with demand flexibility potentials (e.g. installing IoT devices)
-   unit: €/%
+   unit: €/'%'
    
 Capital Cost|Electricity|Residential|Demand Flexibility|Maximum Storage:
    description: Fixed costs associated with demand flexibility potentials (e.g. installing IoT devices)
-   unit: €/%
+   unit: €/'%'

--- a/variable/technology/technologies.yaml
+++ b/variable/technology/technologies.yaml
@@ -1092,26 +1092,7 @@ Rate Automatic Frequency Restoration Reserve|Electricity|Wind|OffShore:
    
 # description of Demand flexibility potentials
    
-Maximum Active power|Electricity|Residential|Demand Flexibility:
-   description: Potential for demand response in a given region/time frame, 
-                expressed as '%' decrease in residential electricity demand,
-                analogous to inputting power from a storage unit.
-   unit: '%'
-   
-Maximum Storage|Electricity|Residential|Demand Flexibility:
-   description: Potential for demand dispatch in a given region/time frame,
-                expressed as '%' increase in residential electricity demand,
-                analogous to drawing power into storage unit.
-   unit: '%'
-   
-Variable Cost|Electricity|Residential|Demand Flexibility:
-   description: Marginal cost of Demand Flexibility in residential electricity demand
-   unit: €/'%' change
-   
-Capital Cost|Electricity|Residential|Demand Flexibility|Maximum Active power:
-   description: Fixed costs associated with demand flexibility potentials (e.g. installing IoT devices)
-   unit: €/'%'
-   
-Capital Cost|Electricity|Residential|Demand Flexibility|Maximum Storage:
-   description: Fixed costs associated with demand flexibility potentials (e.g. installing IoT devices)
-   unit: €/'%'
+Load Shifting Potential|Electricity|Residential|AC:
+   description: Maximum shiftable load in a given region/time frame,
+                due to households changing their air conditioning usage.
+   unit: 'MW'


### PR DESCRIPTION
For case study 1 we will need variables denoting the potential and related costs of demand side flexibility. Lines 1093 - 1118 contain a first take on how such variables could be specified. @sandrinecharousset, @jed