### PR TITLE
Add encoding='utf-8' command

### DIFF
--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -19,7 +19,7 @@ def _parse_yaml(path, file='**/*', ext='.yaml'):
     """Parse `file` in `path` (or all files in subfolders if `file='**/*'`)"""
     dct = {}
     for f in path.glob(f'{file}{ext}'):
-        with open(f, 'r') as stream:
+        with open(f, 'r', encoding='utf-8') as stream:
             _dct = yaml.safe_load(stream)
             # add `file` attribute to each element in the dictionary
             for key, value in _dct.items():

--- a/nomenclature/tests/_test_parse_yaml.py
+++ b/nomenclature/tests/_test_parse_yaml.py
@@ -9,7 +9,7 @@ def test_parse_yaml_files():
     lst = []
     for file in pathlib.Path('.').glob('**/*.yaml'):
         try:
-            with open(file, 'r') as stream:
+            with open(file, 'r', encoding='utf-8') as stream:
                 yaml.safe_load(stream)
         except (yaml.scanner.ScannerError, yaml.parser.ParserError) as e:
             lst.append(f'{file}')


### PR DESCRIPTION
Extend open as stream command with argument encoding='utf-8'
Fix the following error: 
_'charmap' codec can't decode byte 0x8f in position 495_