### PR TITLE
Add `pyam` to setup-config dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,5 +17,5 @@ install_requires =
     pyam-iamc  # the pyam package is released on pypi under this name
 
 [options.package_data]
-nomenclature =
-    definitions/**
+definitions =
+    nomenclature/definitions/**

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,5 +17,5 @@ install_requires =
     pyam-iamc  # the pyam package is released on pypi under this name
 
 [options.package_data]
-definitions =
+nomenclature =
     nomenclature/definitions/**

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,14 +10,7 @@ url = https://github.com/openENTRANCE/nomenclature
 
 [options]
 packages = nomenclature
-include_package_data = True
 install_requires =
     setuptools >= 41
     pyyaml
-setup_requires =
-    setuptools >= 41
-    setuptools_scm
-
-[options.package_data]
-iam_units =
-    nomenclature/*
+    pyam-iamc  # the pyam package is released on pypi under this name

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,12 @@ url = https://github.com/openENTRANCE/nomenclature
 
 [options]
 packages = nomenclature
+include_package_data = True
 install_requires =
     setuptools >= 41
     pyyaml
     pyam-iamc  # the pyam package is released on pypi under this name
+
+[options.package_data]
+nomenclature =
+    nomenclature/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,4 @@ install_requires =
 
 [options.package_data]
 nomenclature =
-    nomenclature/definitions/**
+    nomenclature/definitions/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,4 @@ install_requires =
 
 [options.package_data]
 nomenclature =
-    nomenclature/*
+    definitions/**

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,9 @@ install_requires =
     setuptools >= 41
     pyyaml
     pyam-iamc  # the pyam package is released on pypi under this name
+setup_requires =
+    setuptools >= 41
+    setuptools_scm
 
 [options.package_data]
 nomenclature =


### PR DESCRIPTION
This PR adds the pyam package to the list of dependencies in setup-config