### PR TITLE
Addition of output variables for plan4eu

### DIFF
--- a/nomenclature/definitions/variable/technology/electrity-operation.yaml
+++ b/nomenclature/definitions/variable/technology/electrity-operation.yaml
@@ -78,6 +78,25 @@ Active power|Electricity|Energy Storage System:
    description: Active Power of energy storage systems, excl. hydro storage
    unit: MWh
    
+# Storage per technology
+# (generally hourly, daily or weekly) level of storage available per technology
+
+Storage|Electricity|Hydro|Reservoir:
+   description: Available storage of "simple Hydro reservoir " units
+   unit: MWh
+   
+Storage|Electricity|Hydro|Pumped Storage:
+   description: Available storage of "Pumped Storage " units
+   unit: MWh
+     
+Storage|Electricity|Energy Storage System:
+   description: Available storage of energy storage systems, excl. hydro storage
+   unit: MWh
+
+Storage|Electricity|Load Curtailement:
+   description: remaining amount of curtailement
+   unit: MWh
+   
 # Operation Cost per technologies
 # i.e.  operation cost of aggregated committments of plants, storages and demand-side systems
 
@@ -293,3 +312,33 @@ Inertia|Electricity|Hydro|Pumped Storage:
 Inertia|Electricity|Hydro|Run available for River:
    description: Inertia available for "Run available for River" units
    unit: s
+
+# Marginal costs associated to active power demand, reserves, CO2 emissions, inertia and flows in the grid
+
+Marginal Cost|CO2 Emissions|Electricity:
+   description: Marginal Cost associated to the constraint in terms of CO2 emissions by the electricity power sector
+   unit: €/MWh
+   
+Marginal Cost|Final Energy|Electricity:
+   description: Marginal Cost associated to the electricity demand constraint
+   unit: €/MWh
+
+Marginal Cost|Maximum Flow|Electricity|Transmission:
+   description: Marginal Cost associated to the maximum flow constraint in a line
+   unit: €/MWh
+   
+Marginal Cost|Minimum Flow|Electricity|Transmission:
+   description: Marginal Cost associated to the minimum flow constraint in a line
+   unit: €/MWh
+   
+Marginal Cost|Network|Electricity|Demand|Inertia:
+   description: Marginal Cost associated to the inertia requirement
+   unit: €/MWh
+   
+Marginal Cost|Network|Electricity|Demand|Reserve|Automatic Frequency Restoration:
+   description: Marginal Cost associated to the Automatic Frequency Restoration requirement
+   unit: €/MWh
+   
+Marginal Cost|Network|Electricity|Demand|Reserve|Frequency Containment:
+   description: Marginal Cost associated to the Frequency Containment requirement
+   unit: €/MWh

--- a/nomenclature/definitions/variable/technology/electrity-operation.yaml
+++ b/nomenclature/definitions/variable/technology/electrity-operation.yaml
@@ -15,66 +15,90 @@
 # Active Power per technologies
 # i.e.  aggregated committed (in general hourly) schedules of plants
 
-Active power|Electricity|Biomass|Traditionnal:
+Active Power|Electricity|Biomass:
+   description: Active power of Biomass power plants
+   unit: MWh
+   
+Active Power|Electricity|Biomass|Traditionnal:
    description: Active power of  Traditionnal Biomass power plants
                 biomass from local and pre-existing
                 resources mostly waste :domestic and agricultural waste, forest residues.
    unit: MWh
 
-Active power|Electricity|Biomass|New and imported:
+Active Power|Electricity|Biomass|New and imported:
    description: Active power of New+Imported biomass power plants
                 biomass from dedicated energy crops and biomass imports.
    unit: MWh
 
-Active power|Electricity|Nuclear:
+Active Power|Electricity|Nuclear:
    description: Active power of nuclear power plants
    unit: MWh
 
-Active power|Electricity|Gas|OCGT:
+Active Power|Electricity|Gas:
+   description: Active power of Gas power plants
+   unit: MWh
+   
+Active Power|Electricity|Gas|OCGT:
    description: Active power of Open Cycle Gas Turbine power plants
    unit: MWh
+   
+Active Power|Electricity|Gas|CCGT:
+   description: Active power of Combined Cycle Gas Turbine power plants
+   unit: MWh
 
-Active power|Electricity|Gas|Coal:
+Active Power|Electricity|Coal:
    description: Active power of coal power plants
    unit: MWh
 
-Active power|Electricity|Lignite:
+Active Power|Electricity|Lignite:
    description: Active power of Lignite power plants
    unit: MWh
+
+Active Power|Electricity|Oil:
+   description: Active power of oil power plants
+   unit: MWh   
+
+Active Power|Electricity|Geothermal:
+   description: Active power of Geothermal power plants
+   unit: MWh
    
-Active power|Electricity|Hydro|Reservoir:
+Active Power|Electricity|Hydro|Reservoir:
    description: Active power of "simple Hydro reservoir " units
    unit: MWh
    
-Active power|Electricity|Hydro|Pumped Storage:
+Active Power|Electricity|Hydro|Pumped Storage:
    description: Active power of "Pumped Storage " units
    unit: MWh
    
-Active power|Electricity|Hydro|Run of River:
+Active Power|Electricity|Hydro|Run of River:
    description: Active power of "Run of River" units
    unit: MWh
+
+Active Power|Electricity|Hydro|Ocean:
+   description: Active power of Ocean power plants
+   unit: MWh
    
-Active power|Electricity|Solar:
+Active Power|Electricity|Solar:
    description: Active power of Photovoltaic power plants
    unit: MWh
    
-Active power|Electricity|Wind|OnShore:
+Active Power|Electricity|Wind|OnShore:
    description: Active power of  Wind Onshore power plants
    unit: MWh
    
-Active power|Electricity|Wind|OffShore:
+Active Power|Electricity|Wind|OffShore:
    description: Active power of  Wind OffShore power plants
    unit: MWh
    
-Active power|Electricity|Load Curtailement:
+Active Power|Electricity|Load Curtailement:
    description: Energy curtailed - from the system point of view is equivalent to generation of Active Power
    unit: MWh
    
-Active power|Electricity|Load Shifting:
+Active Power|Electricity|Load Shifting:
    description: Energy shifted - from the system point of view is equivalent to generation of Active Power
    unit: MWh
    
-Active power|Electricity|Energy Storage System:
+Active Power|Electricity|Electricity Storage:
    description: Active Power of energy storage systems, excl. hydro storage
    unit: MWh
    
@@ -100,6 +124,10 @@ Storage|Electricity|Load Curtailement:
 # Operation Cost per technologies
 # i.e.  operation cost of aggregated committments of plants, storages and demand-side systems
 
+Operation Cost|Electricity|Biomass:
+   description: Operation Cost of Biomass power plants
+   unit: €
+
 Operation Cost|Electricity|Biomass|Traditionnal:
    description: Operation Cost of  Traditionnal Biomass power plants
                 biomass from local and pre-existing
@@ -115,18 +143,34 @@ Operation Cost|Electricity|Nuclear:
    description: Operation Cost of nuclear power plants
    unit: €
 
+Operation Cost|Electricity|Geothermal:
+   description: Operation Cost of Geothermal power plants
+   unit: €
+   
+Operation Cost|Electricity|Gas:
+   description: Operation Cost of Gas power plants
+   unit: €
+   
 Operation Cost|Electricity|Gas|OCGT:
    description: Operation Cost of Open Cycle Gas Turbine power plants
    unit: €
 
-Operation Cost|Electricity|Gas|Coal:
+Operation Cost|Electricity|Gas|CCGT:
+   description: Operation Cost of Combined Cycle Gas Turbine power plants
+   unit: €
+   
+Operation Cost|Electricity|Coal:
    description: Operation Cost of coal power plants
    unit: €
 
 Operation Cost|Electricity|Lignite:
    description: Operation Cost of Lignite power plants
    unit: €
-   
+
+Operation Cost|Electricity|Oil:
+   description: Operation Cost of Oil power plants
+   unit: €
+ 
 Operation Cost|Electricity|Hydro|Reservoir:
    description: Operation Cost of "simple Hydro reservoir " units
    unit: €
@@ -137,6 +181,10 @@ Operation Cost|Electricity|Hydro|Pumped Storage:
    
 Operation Cost|Electricity|Hydro|Run of River:
    description: Operation Cost of "Run of River" units
+   unit: €
+
+Operation Cost|Electricity|Hydro|Ocean:
+   description: Operation Cost of Ocean Power plants
    unit: €
    
 Operation Cost|Electricity|Solar:
@@ -151,12 +199,16 @@ Operation Cost|Electricity|Wind|OffShore:
    description: Operation Cost of  Wind OffShore power plants
    unit: €
    
-Operation Cost|Electricity|Energy Storage System:
+Operation Cost|Electricity|Electricity Storage:
    description: Operation Cost of energy storage systems, excl. hydro storage
    unit: €
 
 # Automatic Frequency Restoration Reserve committed per technologies
 # i.e.  Automatic Frequency Restoration Reserve of aggregated committments of plants, storages and demand-side systems
+
+Automatic Frequency Restoration Reserve|Electricity|Biomass:
+   description: Automatic Frequency Restoration Reserve available for  Traditionnal Biomass power plants
+   unit: MWh
 
 Automatic Frequency Restoration Reserve|Electricity|Biomass|Traditionnal:
    description: Automatic Frequency Restoration Reserve available for  Traditionnal Biomass power plants
@@ -172,19 +224,35 @@ Automatic Frequency Restoration Reserve|Electricity|Biomass|New and imported:
 Automatic Frequency Restoration Reserve|Electricity|Nuclear:
    description: Automatic Frequency Restoration Reserve available for nuclear power plants
    unit: MWh
+   
+Automatic Frequency Restoration Reserve|Electricity|Geothermal:
+   description: Automatic Frequency Restoration Reserve available for Geothermal power plants
+   unit: MWh
+
+Automatic Frequency Restoration Reserve|Electricity|Gas:
+   description: Automatic Frequency Restoration Reserve available for Gas power plants
+   unit: MWh
 
 Automatic Frequency Restoration Reserve|Electricity|Gas|OCGT:
    description: Automatic Frequency Restoration Reserve available for Open Cycle Gas Turbine power plants
    unit: MWh
+   
+Automatic Frequency Restoration Reserve|Electricity|Gas|CCGT:
+   description: Automatic Frequency Restoration Reserve available for Combined Cycle Gas Turbine power plants
+   unit: MWh
 
-Automatic Frequency Restoration Reserve|Electricity|Gas|Coal:
+Automatic Frequency Restoration Reserve|Electricity|Coal:
    description: Automatic Frequency Restoration Reserve available for coal power plants
    unit: MWh
 
 Automatic Frequency Restoration Reserve|Electricity|Lignite:
    description: Automatic Frequency Restoration Reserve available for Lignite power plants
    unit: MWh
-   
+
+Automatic Frequency Restoration Reserve|Electricity|Oil:
+   description: Automatic Frequency Restoration Reserve available for Oil power plants
+   unit: MWh
+
 Automatic Frequency Restoration Reserve|Electricity|Hydro|Reservoir:
    description: Automatic Frequency Restoration Reserve available for "simple Hydro reservoir " units
    unit: MWh
@@ -193,8 +261,12 @@ Automatic Frequency Restoration Reserve|Electricity|Hydro|Pumped Storage:
    description: Automatic Frequency Restoration Reserve available for "Pumped Storage " units
    unit: MWh
    
-Automatic Frequency Restoration Reserve|Electricity|Hydro|Run available for River:
-   description: Automatic Frequency Restoration Reserve available for "Run available for River" units
+Automatic Frequency Restoration Reserve|Electricity|Hydro|Run of River:
+   description: Automatic Frequency Restoration Reserve available for "Run of River" units
+   unit: MWh
+   
+Automatic Frequency Restoration Reserve|Electricity|Hydro|Ocean:
+   description: Automatic Frequency Restoration Reserve available for Ocean power plants
    unit: MWh
    
 Automatic Frequency Restoration Reserve|Electricity|Solar:
@@ -209,12 +281,16 @@ Automatic Frequency Restoration Reserve|Electricity|Wind|Available forfShore:
    description: Automatic Frequency Restoration Reserve available for  Wind Available forfShore power plants
    unit: MWh
    
-Automatic Frequency Restoration Reserve|Electricity|Energy Storage System:
+Automatic Frequency Restoration Reserve|Electricity|Electricity Storage:
    description: Automatic Frequency Restoration Reserve available for energy storage systems, excl. hydro storage
    unit: MWh
 
 # Frequency Containment Reserve committed per technologies
 # i.e.  Frequency Containment Reserve of aggregated committments of plants, storages and demand-side systems
+
+Frequency Containment Reserve|Electricity|Biomass:
+   description: Frequency Containment Reserve available for  Traditionnal Biomass power plants
+   unit: MWh
 
 Frequency Containment Reserve|Electricity|Biomass|Traditionnal:
    description: Frequency Containment Reserve available for  Traditionnal Biomass power plants
@@ -231,16 +307,32 @@ Frequency Containment Reserve|Electricity|Nuclear:
    description: Frequency Containment Reserve available for nuclear power plants
    unit: MWh
 
+Frequency Containment Reserve|Electricity|Geothermal:
+   description: Frequency Containment Reserve available for Geothermal power plants
+   unit: MWh
+
+Frequency Containment Reserve|Electricity|Gas:
+   description: Frequency Containment Reserve available for Gas power plants
+   unit: MWh
+
 Frequency Containment Reserve|Electricity|Gas|OCGT:
    description: Frequency Containment Reserve available for Open Cycle Gas Turbine power plants
    unit: MWh
-
-Frequency Containment Reserve|Electricity|Gas|Coal:
+   
+Frequency Containment Reserve|Electricity|Gas|CCGT:
+   description: Frequency Containment Reserve available for Combined Cycle Gas Turbine power plants
+   unit: MWh
+   
+Frequency Containment Reserve|Electricity|Coal:
    description: Frequency Containment Reserve available for coal power plants
    unit: MWh
 
 Frequency Containment Reserve|Electricity|Lignite:
    description: Frequency Containment Reserve available for Lignite power plants
+   unit: MWh
+
+Frequency Containment Reserve|Electricity|Oil:
+   description: Frequency Containment Reserve available for Oil power plants
    unit: MWh
    
 Frequency Containment Reserve|Electricity|Hydro|Reservoir:
@@ -251,8 +343,12 @@ Frequency Containment Reserve|Electricity|Hydro|Pumped Storage:
    description: Frequency Containment Reserve available for "Pumped Storage " units
    unit: MWh
    
-Frequency Containment Reserve|Electricity|Hydro|Run available for River:
-   description: Frequency Containment Reserve available for "Run available for River" units
+Frequency Containment Reserve|Electricity|Hydro|Run of River:
+   description: Frequency Containment Reserve available for "Run of River" units
+   unit: MWh
+
+Frequency Containment Reserve|Electricity|Hydro|Ocean:
+   description: Frequency Containment Reserve available for Ocean Power plants
    unit: MWh
    
 Frequency Containment Reserve|Electricity|Solar:
@@ -267,13 +363,17 @@ Frequency Containment Reserve|Electricity|Wind|Available forfShore:
    description: Frequency Containment Reserve available for  Wind Available forfShore power plants
    unit: MWh
    
-Frequency Containment Reserve|Electricity|Energy Storage System:
+Frequency Containment Reserve|Electricity|Electricity Storage:
    description: Frequency Containment Reserve available for energy storage systems, excl. hydro storage
    unit: MWh
    
 # Inertia provided to the network per technologies
 # i.e. Inertia provided by aggregated committments of plants, storages and demand-side systems  
-   
+  
+Inertia|Electricity|Biomass:
+   description: Inertia available for  Traditionnal Biomass power plants
+   unit: s  
+  
 Inertia|Electricity|Biomass|Traditionnal:
    description: Inertia available for  Traditionnal Biomass power plants
                 biomass from local and pre-existing
@@ -289,16 +389,28 @@ Inertia|Electricity|Nuclear:
    description: Inertia available for nuclear power plants
    unit: s
 
+Inertia|Electricity|Gas:
+   description: Inertia available for Gas power plants
+   unit: s
+   
 Inertia|Electricity|Gas|OCGT:
    description: Inertia available for Open Cycle Gas Turbine power plants
    unit: s
+   
+Inertia|Electricity|Gas|CCGT:
+   description: Inertia available for Combined Cycle Gas Turbine power plants
+   unit: s
 
-Inertia|Electricity|Gas|Coal:
+Inertia|Electricity|Coal:
    description: Inertia available for coal power plants
    unit: s
 
 Inertia|Electricity|Lignite:
    description: Inertia available for Lignite power plants
+   unit: s
+
+Inertia|Electricity|Oil:
+   description: Inertia available for Oil power plants
    unit: s
    
 Inertia|Electricity|Hydro|Reservoir:
@@ -309,8 +421,12 @@ Inertia|Electricity|Hydro|Pumped Storage:
    description: Inertia available for "Pumped Storage " units
    unit: s
    
-Inertia|Electricity|Hydro|Run available for River:
-   description: Inertia available for "Run available for River" units
+Inertia|Electricity|Hydro|Run of River:
+   description: Inertia available for "Run of River" units
+   unit: s
+   
+Inertia|Electricity|Hydro|Ocean:
+   description: Inertia available for Ocean power plants
    unit: s
 
 # Marginal costs associated to active power demand, reserves, CO2 emissions, inertia and flows in the grid

--- a/nomenclature/definitions/variable/technology/electrity-operation.yaml
+++ b/nomenclature/definitions/variable/technology/electrity-operation.yaml
@@ -1,0 +1,137 @@
+# Variables needed for plan4EU results in terms of electricity system operation
+# Schedules per power generation technologies, storages and demand-response
+# includes for each technology:
+#   - Active Power
+#   - Operation Cost
+#   - Reserves committed and Inertia provided
+#   - Levels of storages
+# Marginal costs for:
+#   - Demand in ACtive Power
+#   - Demand in reserves
+#   - Demand in inertia
+#   - Flows in transmission lines
+# Demand not served
+
+# Active Power per technologies
+# i.e.  aggregated committed (in general hourly) schedules of plants
+
+Active power|Electricity|Biomass|Traditionnal:
+   description: Active power of  Traditionnal Biomass power plants
+                biomass from local and pre-existing
+                resources mostly waste :domestic and agricultural waste, forest residues.
+   unit: MWh
+
+Active power|Electricity|Biomass|New and imported:
+   description: Active power of New+Imported biomass power plants
+                biomass from dedicated energy crops and biomass imports.
+   unit: MWh
+
+Active power|Electricity|Nuclear:
+   description: Active power of nuclear power plants
+   unit: MWh
+
+Active power|Electricity|Gas|OCGT:
+   description: Active power of Open Cycle Gas Turbine power plants
+   unit: MWh
+
+Active power|Electricity|Gas|Coal:
+   description: Active power of coal power plants
+   unit: MWh
+
+Active power|Electricity|Lignite:
+   description: Active power of Lignite power plants
+   unit: MWh
+   
+Active power|Electricity|Hydro|Reservoir:
+   description: Active power of "simple Hydro reservoir " units
+   unit: MWh
+   
+Active power|Electricity|Hydro|Pumped Storage:
+   description: Active power of "Pumped Storage " units
+   unit: MWh
+   
+Active power|Electricity|Hydro|Run of River:
+   description: Active power of "Run of River" units
+   unit: MWh
+   
+Active power|Electricity|Solar:
+   description: Active power of Photovoltaic power plants
+   unit: MWh
+   
+Active power|Electricity|Wind|OnShore:
+   description: Active power of  Wind Onshore power plants
+   unit: MWh
+   
+Active power|Electricity|Wind|OffShore:
+   description: Active power of  Wind OffShore power plants
+   unit: MWh
+   
+Active power|Electricity|Load Curtailement:
+   description: Energy curtailed - from the system point of view is equivalent to generation of Active Power
+   unit: MWh
+   
+Active power|Electricity|Load Shifting:
+   description: Energy shifted - from the system point of view is equivalent to generation of Active Power
+   unit: MWh
+   
+Active power|Electricity|Energy Storage System:
+   description: Active Power of energy storage systems, excl. hydro storage
+   unit: MWh
+   
+# Operation Cost per technologies
+# i.e.  operation cost of aggregated committments of plants, storages and demand-side systems
+
+Operation Cost|Electricity|Biomass|Traditionnal:
+   description: Operation Cost of  Traditionnal Biomass power plants
+                biomass from local and pre-existing
+                resources mostly waste :domestic and agricultural waste, forest residues.
+   unit: €
+
+Operation Cost|Electricity|Biomass|New and imported:
+   description: Operation Cost of New+Imported biomass power plants
+                biomass from dedicated energy crops and biomass imports.
+   unit: €
+
+Operation Cost|Electricity|Nuclear:
+   description: Operation Cost of nuclear power plants
+   unit: €
+
+Operation Cost|Electricity|Gas|OCGT:
+   description: Operation Cost of Open Cycle Gas Turbine power plants
+   unit: €
+
+Operation Cost|Electricity|Gas|Coal:
+   description: Operation Cost of coal power plants
+   unit: €
+
+Operation Cost|Electricity|Lignite:
+   description: Operation Cost of Lignite power plants
+   unit: €
+   
+Operation Cost|Electricity|Hydro|Reservoir:
+   description: Operation Cost of "simple Hydro reservoir " units
+   unit: €
+   
+Operation Cost|Electricity|Hydro|Pumped Storage:
+   description: Operation Cost of "Pumped Storage " units
+   unit: €
+   
+Operation Cost|Electricity|Hydro|Run of River:
+   description: Operation Cost of "Run of River" units
+   unit: €
+   
+Operation Cost|Electricity|Solar:
+   description: Operation Cost of Photovoltaic power plants
+   unit: €
+   
+Operation Cost|Electricity|Wind|OnShore:
+   description: Operation Cost of  Wind Onshore power plants
+   unit: €
+   
+Operation Cost|Electricity|Wind|OffShore:
+   description: Operation Cost of  Wind OffShore power plants
+   unit: €
+   
+Operation Cost|Electricity|Energy Storage System:
+   description: Operation Cost of energy storage systems, excl. hydro storage
+   unit: €

--- a/nomenclature/definitions/variable/technology/electrity-operation.yaml
+++ b/nomenclature/definitions/variable/technology/electrity-operation.yaml
@@ -206,164 +206,164 @@ Operation Cost|Electricity|Electricity Storage:
 # Automatic Frequency Restoration Reserve committed per technologies
 # i.e.  Automatic Frequency Restoration Reserve of aggregated committments of plants, storages and demand-side systems
 
-Automatic Frequency Restoration Reserve|Electricity|Biomass:
+Reserve|Electricity|Automatic Frequency Restoration|Biomass:
    description: Automatic Frequency Restoration Reserve available for Traditionnal Biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model 
    unit: MWh
 
-Automatic Frequency Restoration Reserve|Electricity|Biomass|Traditionnal:
+Reserve|Electricity|Automatic Frequency Restoration|Biomass|Traditionnal:
    description: Automatic Frequency Restoration Reserve available for  Traditionnal Biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
                 biomass from local and pre-existing
                 resources mostly waste :domestic and agricultural waste, forest residues.
    unit: MWh
 
-Automatic Frequency Restoration Reserve|Electricity|Biomass|New and imported:
+Reserve|Electricity|Automatic Frequency Restoration|Biomass|New and imported:
    description: Automatic Frequency Restoration Reserve available for New+Imported biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
                 biomass from dedicated energy crops and biomass imports.
    unit: MWh
 
-Automatic Frequency Restoration Reserve|Electricity|Nuclear:
+Reserve|Electricity|Automatic Frequency Restoration|Nuclear:
    description: Automatic Frequency Restoration Reserve available for nuclear power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Automatic Frequency Restoration Reserve|Electricity|Geothermal:
+Reserve|Electricity|Automatic Frequency Restoration|Geothermal:
    description: Automatic Frequency Restoration Reserve available for Geothermal power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Automatic Frequency Restoration Reserve|Electricity|Gas:
+Reserve|Electricity|Automatic Frequency Restoration|Gas:
    description: Automatic Frequency Restoration Reserve available for Gas power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Automatic Frequency Restoration Reserve|Electricity|Gas|OCGT:
+Reserve|Electricity|Automatic Frequency Restoration|Gas|OCGT:
    description: Automatic Frequency Restoration Reserve available for Open Cycle Gas Turbine power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Automatic Frequency Restoration Reserve|Electricity|Gas|CCGT:
+Reserve|Electricity|Automatic Frequency Restoration|Gas|CCGT:
    description: Automatic Frequency Restoration Reserve available for Combined Cycle Gas Turbine power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Automatic Frequency Restoration Reserve|Electricity|Coal:
+Reserve|Electricity|Automatic Frequency Restoration|Coal:
    description: Automatic Frequency Restoration Reserve available for coal power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Automatic Frequency Restoration Reserve|Electricity|Lignite:
+Reserve|Electricity|Automatic Frequency Restoration|Lignite:
    description: Automatic Frequency Restoration Reserve available for Lignite power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Automatic Frequency Restoration Reserve|Electricity|Oil:
+Reserve|Electricity|Automatic Frequency Restoration|Oil:
    description: Automatic Frequency Restoration Reserve available for Oil power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Automatic Frequency Restoration Reserve|Electricity|Hydro|Reservoir:
+Reserve|Electricity|Automatic Frequency Restoration|Hydro|Reservoir:
    description: Automatic Frequency Restoration Reserve available for "simple Hydro reservoir " units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Automatic Frequency Restoration Reserve|Electricity|Hydro|Pumped Storage:
+Reserve|Electricity|Automatic Frequency Restoration|Pumped Storage:
    description: Automatic Frequency Restoration Reserve available for "Pumped Storage " units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Automatic Frequency Restoration Reserve|Electricity|Hydro|Run of River:
+Reserve|Electricity|Automatic Frequency Restoration|Hydro|Run of River:
    description: Automatic Frequency Restoration Reserve available for "Run of River" units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Automatic Frequency Restoration Reserve|Electricity|Hydro|Ocean:
+Reserve|Electricity|Automatic Frequency Restoration|Hydro|Ocean:
    description: Automatic Frequency Restoration Reserve available for Ocean power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Automatic Frequency Restoration Reserve|Electricity|Solar:
+Reserve|Electricity|Automatic Frequency Restoration|Solar:
    description: Automatic Frequency Restoration Reserve available for Photovoltaic power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Automatic Frequency Restoration Reserve|Electricity|Wind|OnShore:
+Reserve|Electricity|Automatic Frequency Restoration|Wind|OnShore:
    description: Automatic Frequency Restoration Reserve available for  Wind Onshore power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Automatic Frequency Restoration Reserve|Electricity|Wind|Available forfShore:
+Reserve|Electricity|Automatic Frequency Restoration|Wind|Available forfShore:
    description: Automatic Frequency Restoration Reserve available for  Wind Available forfShore power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Automatic Frequency Restoration Reserve|Electricity|Electricity Storage:
+Reserve|Electricity|Automatic Frequency Restoration|Electricity Storage:
    description: Automatic Frequency Restoration Reserve available for energy storage systems, excl. hydro storage; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 # Frequency Containment Reserve committed per technologies
 # i.e.  Frequency Containment Reserve of aggregated committments of plants, storages and demand-side systems
 
-Frequency Containment Reserve|Electricity|Biomass:
+Reserve|Electricity|Frequency Containment|Biomass:
    description: Frequency Containment Reserve available for  Traditionnal Biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Frequency Containment Reserve|Electricity|Biomass|Traditionnal:
+Reserve|Electricity|Frequency Containment|Biomass|Traditionnal:
    description: Frequency Containment Reserve available for  Traditionnal Biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
                 biomass from local and pre-existing
                 resources mostly waste :domestic and agricultural waste, forest residues.
    unit: MWh
 
-Frequency Containment Reserve|Electricity|Biomass|New and imported:
+Reserve|Electricity|Frequency Containment|Biomass|New and imported:
    description: Frequency Containment Reserve available for New+Imported biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
                 biomass from dedicated energy crops and biomass imports.
    unit: MWh
 
-Frequency Containment Reserve|Electricity|Nuclear:
+Reserve|Electricity|Frequency Containment|Nuclear:
    description: Frequency Containment Reserve available for nuclear power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Frequency Containment Reserve|Electricity|Geothermal:
+Reserve|Electricity|Frequency Containment|Geothermal:
    description: Frequency Containment Reserve available for Geothermal power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Frequency Containment Reserve|Electricity|Gas:
+Reserve|Electricity|Frequency Containment|Gas:
    description: Frequency Containment Reserve available for Gas power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Frequency Containment Reserve|Electricity|Gas|OCGT:
+Reserve|Electricity|Frequency Containment|Gas|OCGT:
    description: Frequency Containment Reserve available for Open Cycle Gas Turbine power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Frequency Containment Reserve|Electricity|Gas|CCGT:
+Reserve|Electricity|Frequency Containment|Gas|CCGT:
    description: Frequency Containment Reserve available for Combined Cycle Gas Turbine power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Frequency Containment Reserve|Electricity|Coal:
+Reserve|Electricity|Frequency Containment|Coal:
    description: Frequency Containment Reserve available for coal power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Frequency Containment Reserve|Electricity|Lignite:
+Reserve|Electricity|Frequency Containment|Lignite:
    description: Frequency Containment Reserve available for Lignite power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Frequency Containment Reserve|Electricity|Oil:
+Reserve|Electricity|Frequency Containment|Oil:
    description: Frequency Containment Reserve available for Oil power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Frequency Containment Reserve|Electricity|Hydro|Reservoir:
+Reserve|Electricity|Frequency Containment|Hydro|Reservoir:
    description: Frequency Containment Reserve available for "simple Hydro reservoir " units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Frequency Containment Reserve|Electricity|Hydro|Pumped Storage:
+Reserve|Electricity|Frequency Containment|Hydro|Pumped Storage:
    description: Frequency Containment Reserve available for "Pumped Storage " units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Frequency Containment Reserve|Electricity|Hydro|Run of River:
+Reserve|Electricity|Frequency Containment|Hydro|Run of River:
    description: Frequency Containment Reserve available for "Run of River" units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
-Frequency Containment Reserve|Electricity|Hydro|Ocean:
+Reserve|Electricity|Frequency Containment|Hydro|Ocean:
    description: Frequency Containment Reserve available for Ocean Power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Frequency Containment Reserve|Electricity|Solar:
+Reserve|Electricity|Frequency Containment|Solar:
    description: Frequency Containment Reserve available for Photovoltaic power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Frequency Containment Reserve|Electricity|Wind|OnShore:
+Reserve|Electricity|Frequency Containment|Wind|OnShore:
    description: Frequency Containment Reserve available for  Wind Onshore power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Frequency Containment Reserve|Electricity|Wind|Available forfShore:
+Reserve|Electricity|Frequency Containment|Wind|OffShore:
    description: Frequency Containment Reserve available for  Wind Available forfShore power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
-Frequency Containment Reserve|Electricity|Electricity Storage:
+Reserve|Electricity|Frequency Containment|Energy Storage System:
    description: Frequency Containment Reserve available for energy storage systems, excl. hydro storage; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    

--- a/nomenclature/definitions/variable/technology/electrity-operation.yaml
+++ b/nomenclature/definitions/variable/technology/electrity-operation.yaml
@@ -135,3 +135,161 @@ Operation Cost|Electricity|Wind|OffShore:
 Operation Cost|Electricity|Energy Storage System:
    description: Operation Cost of energy storage systems, excl. hydro storage
    unit: €
+
+# Automatic Frequency Restoration Reserve committed per technologies
+# i.e.  Automatic Frequency Restoration Reserve of aggregated committments of plants, storages and demand-side systems
+
+Automatic Frequency Restoration Reserve|Electricity|Biomass|Traditionnal:
+   description: Automatic Frequency Restoration Reserve available for  Traditionnal Biomass power plants
+                biomass from local and pre-existing
+                resources mostly waste :domestic and agricultural waste, forest residues.
+   unit: MWh
+
+Automatic Frequency Restoration Reserve|Electricity|Biomass|New and imported:
+   description: Automatic Frequency Restoration Reserve available for New+Imported biomass power plants
+                biomass from dedicated energy crops and biomass imports.
+   unit: MWh
+
+Automatic Frequency Restoration Reserve|Electricity|Nuclear:
+   description: Automatic Frequency Restoration Reserve available for nuclear power plants
+   unit: MWh
+
+Automatic Frequency Restoration Reserve|Electricity|Gas|OCGT:
+   description: Automatic Frequency Restoration Reserve available for Open Cycle Gas Turbine power plants
+   unit: MWh
+
+Automatic Frequency Restoration Reserve|Electricity|Gas|Coal:
+   description: Automatic Frequency Restoration Reserve available for coal power plants
+   unit: MWh
+
+Automatic Frequency Restoration Reserve|Electricity|Lignite:
+   description: Automatic Frequency Restoration Reserve available for Lignite power plants
+   unit: MWh
+   
+Automatic Frequency Restoration Reserve|Electricity|Hydro|Reservoir:
+   description: Automatic Frequency Restoration Reserve available for "simple Hydro reservoir " units
+   unit: MWh
+   
+Automatic Frequency Restoration Reserve|Electricity|Hydro|Pumped Storage:
+   description: Automatic Frequency Restoration Reserve available for "Pumped Storage " units
+   unit: MWh
+   
+Automatic Frequency Restoration Reserve|Electricity|Hydro|Run available for River:
+   description: Automatic Frequency Restoration Reserve available for "Run available for River" units
+   unit: MWh
+   
+Automatic Frequency Restoration Reserve|Electricity|Solar:
+   description: Automatic Frequency Restoration Reserve available for Photovoltaic power plants
+   unit: MWh
+   
+Automatic Frequency Restoration Reserve|Electricity|Wind|OnShore:
+   description: Automatic Frequency Restoration Reserve available for  Wind Onshore power plants
+   unit: MWh
+   
+Automatic Frequency Restoration Reserve|Electricity|Wind|Available forfShore:
+   description: Automatic Frequency Restoration Reserve available for  Wind Available forfShore power plants
+   unit: MWh
+   
+Automatic Frequency Restoration Reserve|Electricity|Energy Storage System:
+   description: Automatic Frequency Restoration Reserve available for energy storage systems, excl. hydro storage
+   unit: MWh
+
+# Frequency Containment Reserve committed per technologies
+# i.e.  Frequency Containment Reserve of aggregated committments of plants, storages and demand-side systems
+
+Frequency Containment Reserve|Electricity|Biomass|Traditionnal:
+   description: Frequency Containment Reserve available for  Traditionnal Biomass power plants
+                biomass from local and pre-existing
+                resources mostly waste :domestic and agricultural waste, forest residues.
+   unit: MWh
+
+Frequency Containment Reserve|Electricity|Biomass|New and imported:
+   description: Frequency Containment Reserve available for New+Imported biomass power plants
+                biomass from dedicated energy crops and biomass imports.
+   unit: MWh
+
+Frequency Containment Reserve|Electricity|Nuclear:
+   description: Frequency Containment Reserve available for nuclear power plants
+   unit: MWh
+
+Frequency Containment Reserve|Electricity|Gas|OCGT:
+   description: Frequency Containment Reserve available for Open Cycle Gas Turbine power plants
+   unit: MWh
+
+Frequency Containment Reserve|Electricity|Gas|Coal:
+   description: Frequency Containment Reserve available for coal power plants
+   unit: MWh
+
+Frequency Containment Reserve|Electricity|Lignite:
+   description: Frequency Containment Reserve available for Lignite power plants
+   unit: MWh
+   
+Frequency Containment Reserve|Electricity|Hydro|Reservoir:
+   description: Frequency Containment Reserve available for "simple Hydro reservoir " units
+   unit: MWh
+   
+Frequency Containment Reserve|Electricity|Hydro|Pumped Storage:
+   description: Frequency Containment Reserve available for "Pumped Storage " units
+   unit: MWh
+   
+Frequency Containment Reserve|Electricity|Hydro|Run available for River:
+   description: Frequency Containment Reserve available for "Run available for River" units
+   unit: MWh
+   
+Frequency Containment Reserve|Electricity|Solar:
+   description: Frequency Containment Reserve available for Photovoltaic power plants
+   unit: MWh
+   
+Frequency Containment Reserve|Electricity|Wind|OnShore:
+   description: Frequency Containment Reserve available for  Wind Onshore power plants
+   unit: MWh
+   
+Frequency Containment Reserve|Electricity|Wind|Available forfShore:
+   description: Frequency Containment Reserve available for  Wind Available forfShore power plants
+   unit: MWh
+   
+Frequency Containment Reserve|Electricity|Energy Storage System:
+   description: Frequency Containment Reserve available for energy storage systems, excl. hydro storage
+   unit: MWh
+   
+# Inertia provided to the network per technologies
+# i.e. Inertia provided by aggregated committments of plants, storages and demand-side systems  
+   
+Inertia|Electricity|Biomass|Traditionnal:
+   description: Inertia available for  Traditionnal Biomass power plants
+                biomass from local and pre-existing
+                resources mostly waste :domestic and agricultural waste, forest residues.
+   unit: s
+
+Inertia|Electricity|Biomass|New and imported:
+   description: Inertia available for New+Imported biomass power plants
+                biomass from dedicated energy crops and biomass imports.
+   unit: s
+
+Inertia|Electricity|Nuclear:
+   description: Inertia available for nuclear power plants
+   unit: s
+
+Inertia|Electricity|Gas|OCGT:
+   description: Inertia available for Open Cycle Gas Turbine power plants
+   unit: s
+
+Inertia|Electricity|Gas|Coal:
+   description: Inertia available for coal power plants
+   unit: s
+
+Inertia|Electricity|Lignite:
+   description: Inertia available for Lignite power plants
+   unit: s
+   
+Inertia|Electricity|Hydro|Reservoir:
+   description: Inertia available for "simple Hydro reservoir " units
+   unit: s
+   
+Inertia|Electricity|Hydro|Pumped Storage:
+   description: Inertia available for "Pumped Storage " units
+   unit: s
+   
+Inertia|Electricity|Hydro|Run available for River:
+   description: Inertia available for "Run available for River" units
+   unit: s

--- a/nomenclature/definitions/variable/technology/electrity-operation.yaml
+++ b/nomenclature/definitions/variable/technology/electrity-operation.yaml
@@ -90,7 +90,7 @@ Active Power|Electricity|Wind|OffShore:
    description: Active power of  Wind OffShore power plants
    unit: MWh
    
-Active Power|Electricity|Load Curtailement:
+Active Power|Electricity|Load Curtailment:
    description: Energy curtailed - from the system point of view is equivalent to generation of Active Power
    unit: MWh
    
@@ -117,7 +117,7 @@ Storage|Electricity|Energy Storage System:
    description: Available storage of energy storage systems, excl. hydro storage
    unit: MWh
 
-Storage|Electricity|Load Curtailement:
+Storage|Electricity|Load Curtailment:
    description: remaining amount of curtailement
    unit: MWh
    

--- a/nomenclature/definitions/variable/technology/electrity-operation.yaml
+++ b/nomenclature/definitions/variable/technology/electrity-operation.yaml
@@ -207,226 +207,226 @@ Operation Cost|Electricity|Electricity Storage:
 # i.e.  Automatic Frequency Restoration Reserve of aggregated committments of plants, storages and demand-side systems
 
 Automatic Frequency Restoration Reserve|Electricity|Biomass:
-   description: Automatic Frequency Restoration Reserve available for  Traditionnal Biomass power plants
+   description: Automatic Frequency Restoration Reserve available for Traditionnal Biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model 
    unit: MWh
 
 Automatic Frequency Restoration Reserve|Electricity|Biomass|Traditionnal:
-   description: Automatic Frequency Restoration Reserve available for  Traditionnal Biomass power plants
+   description: Automatic Frequency Restoration Reserve available for  Traditionnal Biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
                 biomass from local and pre-existing
                 resources mostly waste :domestic and agricultural waste, forest residues.
    unit: MWh
 
 Automatic Frequency Restoration Reserve|Electricity|Biomass|New and imported:
-   description: Automatic Frequency Restoration Reserve available for New+Imported biomass power plants
+   description: Automatic Frequency Restoration Reserve available for New+Imported biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
                 biomass from dedicated energy crops and biomass imports.
    unit: MWh
 
 Automatic Frequency Restoration Reserve|Electricity|Nuclear:
-   description: Automatic Frequency Restoration Reserve available for nuclear power plants
+   description: Automatic Frequency Restoration Reserve available for nuclear power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Automatic Frequency Restoration Reserve|Electricity|Geothermal:
-   description: Automatic Frequency Restoration Reserve available for Geothermal power plants
+   description: Automatic Frequency Restoration Reserve available for Geothermal power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Automatic Frequency Restoration Reserve|Electricity|Gas:
-   description: Automatic Frequency Restoration Reserve available for Gas power plants
+   description: Automatic Frequency Restoration Reserve available for Gas power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Automatic Frequency Restoration Reserve|Electricity|Gas|OCGT:
-   description: Automatic Frequency Restoration Reserve available for Open Cycle Gas Turbine power plants
+   description: Automatic Frequency Restoration Reserve available for Open Cycle Gas Turbine power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Automatic Frequency Restoration Reserve|Electricity|Gas|CCGT:
-   description: Automatic Frequency Restoration Reserve available for Combined Cycle Gas Turbine power plants
+   description: Automatic Frequency Restoration Reserve available for Combined Cycle Gas Turbine power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Automatic Frequency Restoration Reserve|Electricity|Coal:
-   description: Automatic Frequency Restoration Reserve available for coal power plants
+   description: Automatic Frequency Restoration Reserve available for coal power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Automatic Frequency Restoration Reserve|Electricity|Lignite:
-   description: Automatic Frequency Restoration Reserve available for Lignite power plants
+   description: Automatic Frequency Restoration Reserve available for Lignite power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Automatic Frequency Restoration Reserve|Electricity|Oil:
-   description: Automatic Frequency Restoration Reserve available for Oil power plants
+   description: Automatic Frequency Restoration Reserve available for Oil power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Automatic Frequency Restoration Reserve|Electricity|Hydro|Reservoir:
-   description: Automatic Frequency Restoration Reserve available for "simple Hydro reservoir " units
+   description: Automatic Frequency Restoration Reserve available for "simple Hydro reservoir " units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Automatic Frequency Restoration Reserve|Electricity|Hydro|Pumped Storage:
-   description: Automatic Frequency Restoration Reserve available for "Pumped Storage " units
+   description: Automatic Frequency Restoration Reserve available for "Pumped Storage " units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Automatic Frequency Restoration Reserve|Electricity|Hydro|Run of River:
-   description: Automatic Frequency Restoration Reserve available for "Run of River" units
+   description: Automatic Frequency Restoration Reserve available for "Run of River" units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Automatic Frequency Restoration Reserve|Electricity|Hydro|Ocean:
-   description: Automatic Frequency Restoration Reserve available for Ocean power plants
+   description: Automatic Frequency Restoration Reserve available for Ocean power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Automatic Frequency Restoration Reserve|Electricity|Solar:
-   description: Automatic Frequency Restoration Reserve available for Photovoltaic power plants
+   description: Automatic Frequency Restoration Reserve available for Photovoltaic power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Automatic Frequency Restoration Reserve|Electricity|Wind|OnShore:
-   description: Automatic Frequency Restoration Reserve available for  Wind Onshore power plants
+   description: Automatic Frequency Restoration Reserve available for  Wind Onshore power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Automatic Frequency Restoration Reserve|Electricity|Wind|Available forfShore:
-   description: Automatic Frequency Restoration Reserve available for  Wind Available forfShore power plants
+   description: Automatic Frequency Restoration Reserve available for  Wind Available forfShore power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Automatic Frequency Restoration Reserve|Electricity|Electricity Storage:
-   description: Automatic Frequency Restoration Reserve available for energy storage systems, excl. hydro storage
+   description: Automatic Frequency Restoration Reserve available for energy storage systems, excl. hydro storage; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 # Frequency Containment Reserve committed per technologies
 # i.e.  Frequency Containment Reserve of aggregated committments of plants, storages and demand-side systems
 
 Frequency Containment Reserve|Electricity|Biomass:
-   description: Frequency Containment Reserve available for  Traditionnal Biomass power plants
+   description: Frequency Containment Reserve available for  Traditionnal Biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Frequency Containment Reserve|Electricity|Biomass|Traditionnal:
-   description: Frequency Containment Reserve available for  Traditionnal Biomass power plants
+   description: Frequency Containment Reserve available for  Traditionnal Biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
                 biomass from local and pre-existing
                 resources mostly waste :domestic and agricultural waste, forest residues.
    unit: MWh
 
 Frequency Containment Reserve|Electricity|Biomass|New and imported:
-   description: Frequency Containment Reserve available for New+Imported biomass power plants
+   description: Frequency Containment Reserve available for New+Imported biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
                 biomass from dedicated energy crops and biomass imports.
    unit: MWh
 
 Frequency Containment Reserve|Electricity|Nuclear:
-   description: Frequency Containment Reserve available for nuclear power plants
+   description: Frequency Containment Reserve available for nuclear power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Frequency Containment Reserve|Electricity|Geothermal:
-   description: Frequency Containment Reserve available for Geothermal power plants
+   description: Frequency Containment Reserve available for Geothermal power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Frequency Containment Reserve|Electricity|Gas:
-   description: Frequency Containment Reserve available for Gas power plants
+   description: Frequency Containment Reserve available for Gas power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Frequency Containment Reserve|Electricity|Gas|OCGT:
-   description: Frequency Containment Reserve available for Open Cycle Gas Turbine power plants
+   description: Frequency Containment Reserve available for Open Cycle Gas Turbine power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Frequency Containment Reserve|Electricity|Gas|CCGT:
-   description: Frequency Containment Reserve available for Combined Cycle Gas Turbine power plants
+   description: Frequency Containment Reserve available for Combined Cycle Gas Turbine power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Frequency Containment Reserve|Electricity|Coal:
-   description: Frequency Containment Reserve available for coal power plants
+   description: Frequency Containment Reserve available for coal power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Frequency Containment Reserve|Electricity|Lignite:
-   description: Frequency Containment Reserve available for Lignite power plants
+   description: Frequency Containment Reserve available for Lignite power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Frequency Containment Reserve|Electricity|Oil:
-   description: Frequency Containment Reserve available for Oil power plants
+   description: Frequency Containment Reserve available for Oil power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Frequency Containment Reserve|Electricity|Hydro|Reservoir:
-   description: Frequency Containment Reserve available for "simple Hydro reservoir " units
+   description: Frequency Containment Reserve available for "simple Hydro reservoir " units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Frequency Containment Reserve|Electricity|Hydro|Pumped Storage:
-   description: Frequency Containment Reserve available for "Pumped Storage " units
+   description: Frequency Containment Reserve available for "Pumped Storage " units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Frequency Containment Reserve|Electricity|Hydro|Run of River:
-   description: Frequency Containment Reserve available for "Run of River" units
+   description: Frequency Containment Reserve available for "Run of River" units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
 
 Frequency Containment Reserve|Electricity|Hydro|Ocean:
-   description: Frequency Containment Reserve available for Ocean Power plants
+   description: Frequency Containment Reserve available for Ocean Power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Frequency Containment Reserve|Electricity|Solar:
-   description: Frequency Containment Reserve available for Photovoltaic power plants
+   description: Frequency Containment Reserve available for Photovoltaic power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Frequency Containment Reserve|Electricity|Wind|OnShore:
-   description: Frequency Containment Reserve available for  Wind Onshore power plants
+   description: Frequency Containment Reserve available for  Wind Onshore power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Frequency Containment Reserve|Electricity|Wind|Available forfShore:
-   description: Frequency Containment Reserve available for  Wind Available forfShore power plants
+   description: Frequency Containment Reserve available for  Wind Available forfShore power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 Frequency Containment Reserve|Electricity|Electricity Storage:
-   description: Frequency Containment Reserve available for energy storage systems, excl. hydro storage
+   description: Frequency Containment Reserve available for energy storage systems, excl. hydro storage; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
    
 # Inertia provided to the network per technologies
 # i.e. Inertia provided by aggregated committments of plants, storages and demand-side systems  
   
 Inertia|Electricity|Biomass:
-   description: Inertia available for  Traditionnal Biomass power plants
+   description: Inertia available for  Traditionnal Biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: s  
   
 Inertia|Electricity|Biomass|Traditionnal:
-   description: Inertia available for  Traditionnal Biomass power plants
+   description: Inertia available for  Traditionnal Biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
                 biomass from local and pre-existing
                 resources mostly waste :domestic and agricultural waste, forest residues.
    unit: s
 
 Inertia|Electricity|Biomass|New and imported:
-   description: Inertia available for New+Imported biomass power plants
+   description: Inertia available for New+Imported biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
                 biomass from dedicated energy crops and biomass imports.
    unit: s
 
 Inertia|Electricity|Nuclear:
-   description: Inertia available for nuclear power plants
+   description: Inertia available for nuclear power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: s
 
 Inertia|Electricity|Gas:
-   description: Inertia available for Gas power plants
+   description: Inertia available for Gas power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: s
    
 Inertia|Electricity|Gas|OCGT:
-   description: Inertia available for Open Cycle Gas Turbine power plants
+   description: Inertia available for Open Cycle Gas Turbine power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: s
    
 Inertia|Electricity|Gas|CCGT:
-   description: Inertia available for Combined Cycle Gas Turbine power plants
+   description: Inertia available for Combined Cycle Gas Turbine power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: s
 
 Inertia|Electricity|Coal:
-   description: Inertia available for coal power plants
+   description: Inertia available for coal power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: s
 
 Inertia|Electricity|Lignite:
-   description: Inertia available for Lignite power plants
+   description: Inertia available for Lignite power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: s
 
 Inertia|Electricity|Oil:
-   description: Inertia available for Oil power plants
+   description: Inertia available for Oil power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: s
    
 Inertia|Electricity|Hydro|Reservoir:
-   description: Inertia available for "simple Hydro reservoir " units
+   description: Inertia available for "simple Hydro reservoir " units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: s
    
 Inertia|Electricity|Hydro|Pumped Storage:
-   description: Inertia available for "Pumped Storage " units
+   description: Inertia available for "Pumped Storage " units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: s
    
 Inertia|Electricity|Hydro|Run of River:
-   description: Inertia available for "Run of River" units
+   description: Inertia available for "Run of River" units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: s
    
 Inertia|Electricity|Hydro|Ocean:
-   description: Inertia available for Ocean power plants
+   description: Inertia available for Ocean power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: s
 
 # Marginal costs associated to active power demand, reserves, CO2 emissions, inertia and flows in the grid


### PR DESCRIPTION
This pull request includes addition of a new file dealing with the outputs of plan4EU in terms of electricity system operation. This does not include outputs in termes of investment decisions. it includes:
* Commitment of all technologies and demand-side systems (aggregated per technology)
      - Active Power (ie generation schedules)
      - Reserves commitments (Frequency restoration reserve and automatic frequency containment reserve)
      - Inertia available for the system
* Levels of aggregated storages
* Marginal costs of following constraints:
      - demand 
      - reserve requirements (Frequency restoration reserve and automatic frequency containment reserve)
      - inertia requirement
      - max/min flows on lines

