### PR TITLE
Adding variables from GENeSYS-MOD power sector

### DIFF
--- a/nomenclature/definitions/variable/energy/energy-secondary.yaml
+++ b/nomenclature/definitions/variable/energy/energy-secondary.yaml
@@ -41,17 +41,63 @@ Secondary Energy|Electricity|Fossil:
    unit: EJ/yr
 
 Secondary Energy|Electricity|Gas:
-   description: Net electricity production from natural gas
+   description: Net electricity production from natural gas (including methane from biomass or hydrogenation)
    unit: EJ/yr
 
 Secondary Energy|Electricity|Gas|w/ CCS:
-   description: Net electricity production from natural gas with a co2 capture
+   description: Net electricity production from natural gas (including methane from biomass or hydrogenation) with a co2 capture
                 component
    unit: EJ/yr
 
 Secondary Energy|Electricity|Gas|w/o CCS:
-   description: Net electricity production from natural gas with freely vented
+   description: Net electricity production from natural gas (including methane from biomass or hydrogenation) with freely vented
                 co2 emissions
+   unit: EJ/yr
+
+Secondary Energy|Electricity|Gas|Fossil:
+   description: Net electricity production from (fossil) natural gas
+   unit: EJ/yr
+
+Secondary Energy|Electricity|Gas|Fossil|w/ CCS:
+   description: Net electricity production from (fossil) natural gas with a co2 capture
+                component
+   unit: EJ/yr
+
+Secondary Energy|Electricity|Gas|Fossil|w/o CCS:
+   description: Net electricity production from (fossil) natural gas with freely vented
+                co2 emissions
+   unit: EJ/yr
+   
+Secondary Energy|Electricity|Gas|Biomethane:
+   description: Net electricity production from biomethane (upgraded biogas)
+   unit: EJ/yr
+
+Secondary Energy|Electricity|Gas|Biomethane|w/ CCS:
+   description: Net electricity production from biomethane (upgraded biogas) with a co2 capture
+                component
+   unit: EJ/yr
+
+Secondary Energy|Electricity|Gas|Biomethane|w/o CCS:
+   description: Net electricity production from biomethane (upgraded biogas) with freely vented
+                co2 emissions
+   unit: EJ/yr
+   
+Secondary Energy|Electricity|Gas|Synthetic Methane:
+   description: Net electricity production from synthetic methane (methanation of hydrogen)
+   unit: EJ/yr
+
+Secondary Energy|Electricity|Gas|Synthetic Methane|w/ CCS:
+   description: Net electricity production from synthetic methane (methanation of hydrogen) with a co2 capture
+                component
+   unit: EJ/yr
+
+Secondary Energy|Electricity|Gas|Synthetic Methane|w/o CCS:
+   description: Net electricity production from synthetic methane (methanation of hydrogen) with freely vented
+                co2 emissions
+   unit: EJ/yr
+      
+Secondary Energy|Electricity|Hydrogen:
+   description: Net electricity production from hydrogen (via fuelcells or hydrogen OCGTs)
    unit: EJ/yr
 
 Secondary Energy|Electricity|Geothermal:

--- a/nomenclature/definitions/variable/technology/technologies.yaml
+++ b/nomenclature/definitions/variable/technology/technologies.yaml
@@ -139,6 +139,19 @@ Capacity|Electricity|Wind|Onshore:
    description: Total installed electricity generation capacity of onshore wind
                 power installations
    unit: GW
+   
+Capacity|Electricity|Hydrogen:
+   description: Total installed electricity generation capacity from hydrogen
+   unit: GW
+
+Capacity|Electricity|Hydrogen|OCGT:
+   description: Total installed electricity generation capacity from hydrogen of Open Cycle Gas Turbines
+                plants
+   unit: GW
+
+Capacity|Electricity|Hydrogen|Fuel Cell:
+   description: Total installed electricity generation capacity from hydrogen of fuelcell plants
+   unit: GW  
 
 Capital Cost|Electricity|Biomass|w/ CCS:
    description: Capital cost of a new biomass power plant with CCS


### PR DESCRIPTION
First, I added different types of methane used in electricity production (biomethane, natural gas, and synthetic methane). Therefore, `Secondary Energy|Electricity|Gas` is now an aggregate of all methane/natural gas-type fuels.

I added hydrogen power generation plants in `technologies.yaml`

Lastly, comments from #37 were also included.