### PR TITLE
Addition of variables related to electricity-grid from openTEPES

### DIFF
--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -65,7 +65,7 @@ Minimum Flow|Electricity|Transmission:
    description: Minimum flow of an interconnection between 2 regions
    unit: MW
 
-Reserve|Electricity|Requirement|Operating Reserve Down:
+Reserve|Electricity|Requirement|Operating Reserve|Down:
    description: Operating reserve down of the system for each load level. It is the sum of aFRR (or secondary reserve), FRR & RR (FRR+RR = tertiary reserve).
    unit: MW
 

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -77,7 +77,7 @@ Reactance|Electricity|Transmission:
    description: Reactance. Lines need to have a reactance different from 0 in the case of a DC cable or a transportation modeling for an AC cable
    unit:
 
-Replacement Reserve|Electricity:
+Reserve|Electricity|Replacement:
    description: Replacement reserve (RR) means the active power reserves available to restore or support the required level of frequency restoration reserve (FRR) to be prepared for additional system imbalances, including generation reserves.
    unit: MW
 

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -69,7 +69,7 @@ Operating Reserve Down|Electricity:
    description: Operating reserve down of the system for each load level. It is the sum of aFRR (or secondary reserve), FRR & RR (FRR+RR = tertiary reserve).
    unit: MW
 
-Operating Reserve Up|Electricity:
+Reserve|Electricity|Requirement|Operating Reserve Up:
    description: Operating reserve up of the system for each load level. It is the sum of aFRR (or secondary reserve), FRR & RR (FRR+RR = tertiary reserve).
    unit: MW
 

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -25,10 +25,6 @@ Network|Electricity|Active Power Flow:
    description: Active power flow through a line
    unit: MW
 
-Network|Electricity|Investment:
-   description: Investment decision. Note that it is a output data from model and if it makes a product with the investmen cost of the line, we get the investment in monetary unit.
-   unit: [Yes, No]
-
 Network|Electricity|Impedance:
    description: Impedance of an interconnection between 2 regions
    unit: S

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -8,7 +8,7 @@ Demand not served|Electricity:
    description: Demand-not-served.
    unit: MWh
 
-Network|Electricity|Demand|Reserve|Frequency Containment:
+Reserve|Electricity|Requirement|Frequency Containment:
    description: Demand in frequency containment reserve (FCR)
    unit: MW
 

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -42,7 +42,7 @@ Network|Electricity|Line Type:
    unit: [AC, DC]
 
 Network|Electricity|Line Losses:
-   description: Half ohmic losses of a line because losses are divided and located at each of the connection points of the transmission line.
+   description: Total ohmic losses of a transmission line.
    unit: MW
 
 Network|Electricity|Loss Factor:

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -53,7 +53,7 @@ Loss Factor|Electricity|Transmission:
    description: Transmission losses equal to the line flow times this factor
    unit:
 
-Manual Frequency Restoration Reserve|Electricity:
+Reserve|Electricity|Requirement|Manual Frequency Restoration:
    description: Manual frequency restoration reserve (mFRR) is used to relieve the automatic frequency restoration reserve during prolonged imbalances.
    unit: MW
 

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -1,5 +1,5 @@
 # List of variables related to the electricity grid
-# description of variables related to electricity demand
+# Variables related to electricity demand
 Network|Electricity|Value of Lost Load:
    description: Cost of demand-not-served. Cost of load curtailment. Value of Lost Load (VoLL)
    unit: €/MWh
@@ -20,7 +20,7 @@ Network|Electricity|Requirement|Inertia:
    description: Demand in inertia
    unit: second
 
-# description of variables related to transmission lines
+# Variables related to transmission lines
 Network|Electricity|Active Power Flow:
    description: Active power flow through a line
    unit: MW

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -46,7 +46,7 @@ Network|Electricity|Line Type:
    unit: [AC, DC]
 
 Network|Electricity|Line Losses:
-   description: Half ohmic losses of a line
+   description: Half ohmic losses of a line because losses are located at each of the connection points of the transmission line.
    unit: MW
 
 Network|Electricity|Loss Factor:

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -25,8 +25,8 @@ Active Power Flow|Electricity|Transmission:
    description: Active power flow through a line
    unit: MW
 
-Binary Investment|Electricity|Transmission:
-   description: Binary line/circuit investment decision. Note that it is a output data from model and if it makes a product with the investmen cost of the line, we get the investment in monetary unit.
+Investment|Electricity|Transmission:
+   description: Investment decision. Note that it is a output data from model and if it makes a product with the investmen cost of the line, we get the investment in monetary unit.
    unit: [Yes, No]
 
 Impedance|Electricity|Transmission:

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -69,7 +69,7 @@ Reserve|Electricity|Requirement|Operating Reserve|Down:
    description: Operating reserve down of the system for each load level. It is the sum of aFRR (or secondary reserve), FRR & RR (FRR+RR = tertiary reserve).
    unit: MW
 
-Reserve|Electricity|Requirement|Operating Reserve Up:
+Reserve|Electricity|Requirement|Operating Reserve|Up:
    description: Operating reserve up of the system for each load level. It is the sum of aFRR (or secondary reserve), FRR & RR (FRR+RR = tertiary reserve).
    unit: MW
 

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -65,7 +65,7 @@ Minimum Flow|Electricity|Transmission:
    description: Minimum flow of an interconnection between 2 regions
    unit: MW
 
-Operating Reserve Down|Electricity:
+Reserve|Electricity|Requirement|Operating Reserve Down:
    description: Operating reserve down of the system for each load level. It is the sum of aFRR (or secondary reserve), FRR & RR (FRR+RR = tertiary reserve).
    unit: MW
 

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -1,25 +1,90 @@
 # List of variables related to the electricity grid
+# description of variables related to electricity demand
+Value of Lost Load|Electricity:
+   description: Cost of demand-not-served. Cost of load curtailment. Value of Lost Load (VoLL)
+   unit: €/MWh
+
+Demand-not-served|Electricity:
+   description: Demand-not-served.
+   unit: MWh
 
 Network|Electricity|Demand|Reserve|Frequency Containment:
-   description: demand in frequency containment reserve (FCR)            
+   description: Demand in frequency containment reserve (FCR)
    unit: MW
-   
+
 Network|Electricity|Demand|Reserve|Automatic Frequency Restoration:
-   description: demand in automatic frequency restoration reserve (AFRR)             
+   description: Demand in automatic frequency restoration reserve (AFRR)
    unit: MW
-   
+
 Network|Electricity|Demand|Inertia:
-   description: demand in inertia            
+   description: Demand in inertia
    unit: second
-   
-Maximum Flow|Electricity|Grid:
-   description: maximum flow of an interconnection between 2 regions
+
+# description of variables related to transmission lines
+Active Power Flow|Electricity|Transmission:
+   description: Active power flow through a line
    unit: MW
-   
-Minimum Flow|Electricity|Grid:
-   description: minimum flow of an interconnection between 2 regions
-   unit: MW
-   
-Impedance|Electricity|Grid:
-   description: impedance of an interconnection between 2 regions
+
+Binary Investment|Electricity|Transmission:
+   description: Binary line/circuit investment decision. Note that it is a output data from model and if it makes a product with the investmen cost of the line, we get the investment in monetary unit.
+   unit: [Yes, No]
+
+Impedance|Electricity|Transmission:
+   description: Impedance of an interconnection between 2 regions
    unit: S
+
+Investment|Electricity|Transmission:
+   description: Overnight investment (capital) cost in transmission lines of the power network
+   unit: billion US$2010/yr
+
+Fixed Charge Rate|Electricity|Transmission:
+   description: Fixed charge rate to annualize the overnight investment cost. The Fixed Charge Rate (FCR) is the percentage of the total investment cost that is required over the project life per year to cover the minimal annual revenue requirements.
+   unit:
+
+Line Type|Electricity|Transmission:
+   description: Line type related to alternating current (AC) and direct current (DC)
+   unit: [AC, DC]
+
+Line Losses|Electricity|Transmission:
+   description: Half ohmic losses of a line
+   unit: MW
+
+Loss Factor|Electricity|Transmission:
+   description: Transmission losses equal to the line flow times this factor
+   unit:
+
+Manual Frequency Restoration Reserve|Electricity:
+   description: Manual frequency restoration reserve (mFRR) is used to relieve the automatic frequency restoration reserve during prolonged imbalances.
+   unit: MW
+
+Maximum Flow|Electricity|Transmission:
+   description: Maximum flow of a transmission line between 2 regions (i.e. aggregate-regions, countries, nuts1, nuts2, nuts3, or nodes). Total transfer capacity (TTC). (maximum permissible thermal load)
+   unit: MW
+
+Minimum Flow|Electricity|Transmission:
+   description: Minimum flow of an interconnection between 2 regions
+   unit: MW
+
+Operating Reserve Down|Electricity:
+   description: Operating reserve down of the system for each load level. It is the sum of aFRR (or secondary reserve), FRR & RR (FRR+RR = tertiary reserve).
+   unit: MW
+
+Operating Reserve Up|Electricity:
+   description: Operating reserve up of the system for each load level. It is the sum of aFRR (or secondary reserve), FRR & RR (FRR+RR = tertiary reserve).
+   unit: MW
+
+Reactance|Electricity|Transmission:
+   description: Reactance. Lines need to have a reactance different from 0 in the case of a DC cable or a transportation modeling for an AC cable
+   unit:
+
+Replacement Reserve|Electricity:
+   description: Replacement reserve (RR) means the active power reserves available to restore or support the required level of frequency restoration reserve (FRR) to be prepared for additional system imbalances, including generation reserves.
+   unit: MW
+
+Security Factor|Electricity|Transmission:
+   description: Security factor to consider approximately N-1 contingencies. NTC = TTC x SecurityFactor
+   unit:
+
+Voltage Angle|Electricity:
+   description: Voltage angle of a node
+   unit: Rad

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -1,18 +1,18 @@
 # List of variables related to the electricity grid
 # description of variables related to electricity demand
-Value of Lost Load|Electricity:
+Network|Electricity|Value of Lost Load:
    description: Cost of demand-not-served. Cost of load curtailment. Value of Lost Load (VoLL)
    unit: €/MWh
 
-Demand not served|Electricity:
+Network|Electricity|Demand not served:
    description: Demand-not-served.
    unit: MWh
 
-Reserve|Electricity|Requirement|Frequency Containment:
+Network|Electricity|Reserve|Requirement|Frequency Containment:
    description: Demand in frequency containment reserve (FCR)
    unit: MW
 
-Reserve|Electricity|Requirement|Automatic Frequency Restoration:
+Network|Electricity|Reserve|Requirement|Automatic Frequency Restoration:
    description: Demand in automatic frequency restoration reserve (AFRR)
    unit: MW
 
@@ -31,7 +31,7 @@ Network|Electricity|Impedance:
 
 Network|Electricity|Investment:
    description: Overnight investment (capital) cost in transmission lines of the power network
-   unit: billion US$2010/yr
+   unit: [million EUR/yr, billion US$2010/yr]
 
 Network|Electricity|Fixed Charge Rate:
    description: Fixed charge rate to annualize the overnight investment cost. The Fixed Charge Rate (FCR) is the percentage of the total investment cost that is required over the project life per year to cover the minimal annual revenue requirements.
@@ -61,11 +61,11 @@ Network|Electricity|Minimum Flow:
    description: Minimum flow of electricity on a transmission line
    unit: MW
 
-Reserve|Electricity|Requirement|Operating Reserve|Down:
+Network|Electricity|Reserve|Requirement|Operating Reserve|Down:
    description: Operating reserve down of the system for each load level. It is the sum of aFRR (or secondary reserve), FRR & RR (FRR+RR = tertiary reserve).
    unit: MW
 
-Reserve|Electricity|Requirement|Operating Reserve|Up:
+Network|Electricity|Reserve|Requirement|Operating Reserve|Up:
    description: Operating reserve up of the system for each load level. It is the sum of aFRR (or secondary reserve), FRR & RR (FRR+RR = tertiary reserve).
    unit: MW
 
@@ -82,5 +82,5 @@ Network|Electricity|Security Factor:
    unit:
 
 Network|Electricity|Voltage Angle:
-   description: Voltage angle of a node
+   description: Voltage angle at a node
    unit: Rad

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -58,7 +58,7 @@ Network|Electricity|Maximum Flow:
    unit: MW
 
 Network|Electricity|Minimum Flow:
-   description: Minimum flow of an interconnection between 2 regions
+   description: Minimum flow of electricity on a transmission line
    unit: MW
 
 Reserve|Electricity|Requirement|Operating Reserve|Down:

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -54,7 +54,7 @@ Reserve|Electricity|Requirement|Manual Frequency Restoration:
    unit: MW
 
 Network|Electricity|Maximum Flow:
-   description: Maximum flow of a transmission line between 2 regions (i.e. aggregate-regions, countries, nuts1, nuts2, nuts3, or nodes). Total transfer capacity (TTC). (maximum permissible thermal load)
+   description: Maximum flow of electricity on a transmission line
    unit: MW
 
 Network|Electricity|Minimum Flow:

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -46,7 +46,7 @@ Network|Electricity|Line Type:
    unit: [AC, DC]
 
 Network|Electricity|Line Losses:
-   description: Half ohmic losses of a line because losses are located at each of the connection points of the transmission line.
+   description: Half ohmic losses of a line because losses are divided and located at each of the connection points of the transmission line.
    unit: MW
 
 Network|Electricity|Loss Factor:

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -16,7 +16,7 @@ Reserve|Electricity|Requirement|Automatic Frequency Restoration:
    description: Demand in automatic frequency restoration reserve (AFRR)
    unit: MW
 
-Network|Electricity|Demand|Inertia:
+Network|Electricity|Requirement|Inertia:
    description: Demand in inertia
    unit: second
 

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -21,35 +21,35 @@ Network|Electricity|Requirement|Inertia:
    unit: second
 
 # description of variables related to transmission lines
-Active Power Flow|Electricity|Transmission:
+Network|Electricity|Active Power Flow:
    description: Active power flow through a line
    unit: MW
 
-Investment|Electricity|Transmission:
+Network|Electricity|Investment:
    description: Investment decision. Note that it is a output data from model and if it makes a product with the investmen cost of the line, we get the investment in monetary unit.
    unit: [Yes, No]
 
-Impedance|Electricity|Transmission:
+Network|Electricity|Impedance:
    description: Impedance of an interconnection between 2 regions
    unit: S
 
-Investment|Electricity|Transmission:
+Network|Electricity|Investment:
    description: Overnight investment (capital) cost in transmission lines of the power network
    unit: billion US$2010/yr
 
-Fixed Charge Rate|Electricity|Transmission:
+Network|Electricity|Fixed Charge Rate:
    description: Fixed charge rate to annualize the overnight investment cost. The Fixed Charge Rate (FCR) is the percentage of the total investment cost that is required over the project life per year to cover the minimal annual revenue requirements.
    unit:
 
-Line Type|Electricity|Transmission:
+Network|Electricity|Line Type:
    description: Line type related to alternating current (AC) and direct current (DC)
    unit: [AC, DC]
 
-Line Losses|Electricity|Transmission:
+Network|Electricity|Line Losses:
    description: Half ohmic losses of a line
    unit: MW
 
-Loss Factor|Electricity|Transmission:
+Network|Electricity|Loss Factor:
    description: Transmission losses equal to the line flow times this factor
    unit:
 
@@ -57,11 +57,11 @@ Reserve|Electricity|Requirement|Manual Frequency Restoration:
    description: Manual frequency restoration reserve (mFRR) is used to relieve the automatic frequency restoration reserve during prolonged imbalances.
    unit: MW
 
-Maximum Flow|Electricity|Transmission:
+Network|Electricity|Maximum Flow:
    description: Maximum flow of a transmission line between 2 regions (i.e. aggregate-regions, countries, nuts1, nuts2, nuts3, or nodes). Total transfer capacity (TTC). (maximum permissible thermal load)
    unit: MW
 
-Minimum Flow|Electricity|Transmission:
+Network|Electricity|Minimum Flow:
    description: Minimum flow of an interconnection between 2 regions
    unit: MW
 
@@ -73,7 +73,7 @@ Reserve|Electricity|Requirement|Operating Reserve|Up:
    description: Operating reserve up of the system for each load level. It is the sum of aFRR (or secondary reserve), FRR & RR (FRR+RR = tertiary reserve).
    unit: MW
 
-Reactance|Electricity|Transmission:
+Network|Electricity|Reactance:
    description: Reactance. Lines need to have a reactance different from 0 in the case of a DC cable or a transportation modeling for an AC cable
    unit:
 
@@ -81,10 +81,10 @@ Reserve|Electricity|Replacement:
    description: Replacement reserve (RR) means the active power reserves available to restore or support the required level of frequency restoration reserve (FRR) to be prepared for additional system imbalances, including generation reserves.
    unit: MW
 
-Security Factor|Electricity|Transmission:
+Network|Electricity|Security Factor:
    description: Security factor to consider approximately N-1 contingencies. NTC = TTC x SecurityFactor
    unit:
 
-Voltage Angle|Electricity|Transmission:
+Network|Electricity|Voltage Angle:
    description: Voltage angle of a node
    unit: Rad

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -37,10 +37,6 @@ Network|Electricity|Fixed Charge Rate:
    description: Fixed charge rate to annualize the overnight investment cost. The Fixed Charge Rate (FCR) is the percentage of the total investment cost that is required over the project life per year to cover the minimal annual revenue requirements.
    unit:
 
-Network|Electricity|Line Type:
-   description: Line type related to alternating current (AC) and direct current (DC)
-   unit: [AC, DC]
-
 Network|Electricity|Line Losses:
    description: Total ohmic losses of a transmission line.
    unit: MW

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -4,7 +4,7 @@ Value of Lost Load|Electricity:
    description: Cost of demand-not-served. Cost of load curtailment. Value of Lost Load (VoLL)
    unit: €/MWh
 
-Demand-not-served|Electricity:
+Demand not served|Electricity:
    description: Demand-not-served.
    unit: MWh
 

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -85,6 +85,6 @@ Security Factor|Electricity|Transmission:
    description: Security factor to consider approximately N-1 contingencies. NTC = TTC x SecurityFactor
    unit:
 
-Voltage Angle|Electricity:
+Voltage Angle|Electricity|Transmission:
    description: Voltage angle of a node
    unit: Rad

--- a/nomenclature/definitions/variable/technology/electricity-grid.yaml
+++ b/nomenclature/definitions/variable/technology/electricity-grid.yaml
@@ -12,7 +12,7 @@ Reserve|Electricity|Requirement|Frequency Containment:
    description: Demand in frequency containment reserve (FCR)
    unit: MW
 
-Network|Electricity|Demand|Reserve|Automatic Frequency Restoration:
+Reserve|Electricity|Requirement|Automatic Frequency Restoration:
    description: Demand in automatic frequency restoration reserve (AFRR)
    unit: MW
 


### PR DESCRIPTION
Addition of variables from openTEPES to electricity-grid related to the grid.
Variables such as: Investment, line type, line losses, reactance, etc.