### PR TITLE
Refactoring and simplifying of variables related to power plant specifications

### DIFF
--- a/nomenclature/definitions/variable/technology/power-plant.yaml
+++ b/nomenclature/definitions/variable/technology/power-plant.yaml
@@ -3,638 +3,153 @@
 # Note that:
 # linear   term cost   [EUR/GWh] = Linear Var Cost [Mcal/MWh] * Price|Primary Energy [EUR/Mcal] + Operation and Maintenance Variable Cost [EUR/MWh] * 1e-3
 # constant term cost   [EUR/h]   = Constant Var Cost [Mcal/h] * Price|Primary Energy [EUR/Mcal]
-Operational Cost|Constant Term|Electricity Generation|Coal:
-   description: Constant term (intercept) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the unit commitment variable of each power plant per unit time.
-   unit: Mcal/hour
 
-Operational Cost|Constant Term|Electricity Generation|Gas:
-   description: Constant term (intercept) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the unit commitment variable of each power plant per unit time.
-   unit: Mcal/hour
-
-Operational Cost|Constant Term|Electricity Generation|Nuclear:
-   description: Constant term (intercept) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the unit commitment variable of each power plant per unit time.
-   unit: Mcal/hour
-
-Operational Cost|Constant Term|Electricity Generation|Oil:
-   description: Constant term (intercept) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the unit commitment variable of each power plant per unit time.
-   unit: Mcal/hour
-
-Operational Cost|Linear Term|Electricity Generation|Coal:
-   description: Linear term (slope) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the production cost of each energy unit (GWh, MWh,etc.).
-   unit: Mcal/MWh
-
-Operational Cost|Linear Term|Electricity Generation|Gas:
-   description: Linear term (slope) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the production cost of each energy unit (GWh, MWh,etc.).
-   unit: Mcal/MWh
-
-Operational Cost|Linear Term|Electricity Generation|Nuclear:
-   description: Linear term (slope) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the production cost of each energy unit (GWh, MWh,etc.).
-   unit: Mcal/MWh
-
-Operational Cost|Linear Term|Electricity Generation|Oil:
-   description: Linear term (slope) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the production cost of each energy unit (GWh, MWh,etc.).
-   unit: Mcal/MWh
-
-Operation and Maintenance Cost|Electricity|Coal:
-   description: Operation and maintenance cost of the power generation unit who belongs to the specified power
-                plant category.
-   unit: EUR/MWh
-
-Operation and Maintenance Cost|Electricity|Gas:
-   description: Operation and maintenance cost of the power generation unit who belongs to the specified power
-                plant category.
-   unit: EUR/MWh
-
-Operation and Maintenance Cost|Electricity|Nuclear:
-   description: Operation and maintenance cost of the power generation unit who belongs to the specified power
-                plant category.
-   unit: EUR/MWh
-
-Operation and Maintenance Cost|Electricity|Oil:
-   description: Operation and maintenance cost of the power generation unit who belongs to the specified power
-                plant category.
-   unit: EUR/MWh
-
-Shut-Down Cost|Electricity|Coal:
-   description: Shutdown heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Shut-Down Cost|Electricity|Gas:
-   description: Shutdown heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Shut-Down Cost|Electricity|Nuclear:
-   description: Shutdown heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Shut-Down Cost|Electricity|Oil:
-   description: Shutdown heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-Start-Up Cost|Electricity|Coal:
-   description: Startup heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Start-Up Cost|Electricity|Gas:
-   description: Startup heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Start-Up Cost|Electricity|Nuclear:
-   description: Startup heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Start-Up Cost|Electricity|Oil:
-   description: Startup heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Variable Cost|Electricity|Biomass|Traditionnal:
-   description: variable cost of a typical Traditionnal Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: EUR/MWh
-
-Variable Cost|Electricity|Biomass|New and imported :
-   description: variable cost of a typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: EUR/MWh
-
-Variable Cost|Electricity|Nuclear:
-   description: variable cost of a typical nuclear power plant
-   unit: EUR/MWh
-
-Variable Cost|Electricity|Gas|OCGT:
-   description: variable cost of a typical Open Cycle Gas Turbine power plant
-   unit: EUR/MWh
-
-Variable Cost|Electricity|Coal:
-   description: variable cost of a typical coal power plant
-   unit: EUR/MWh
-
-Variable Cost|Electricity|Lignite:
-   description: variable cost of a typical Lignite power plant
-   unit: EUR/MWh
-
-# Variables related to thermal power plants
-Number of Units|Electricity|Biomass|Traditional:
-   description: number of units of kind "Traditionnal Biomass power plant "
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit:
-
-Number of Units|Electricity|Biomass|New and imported:
-   description: Number of units of kind "new biomass power plant "
-                biomass from dedicated energy crops and biomass imports.
-   unit:
-
-Number of Units|Electricity|Nuclear:
-   description: Number of units of kind "nuclear power plant "
-   unit:
-
-Number of Units|Electricity|Gas|OCGT:
-   description: Number of units of kind "Open Cycle Gas Turbine power plant"
-   unit:
-
-Number of Units|Electricity|Coal:
-   description: Number of units of kind "coal power plant "
-   unit:
-
-Number of Units|Electricity|Lignite:
-   description: Number of units of kind "Lignite power plant "
-   unit:
-
-Maximum Active Power|Electricity|Biomass|Traditionnal:
-   description: Maximum active power of one typical Traditionnal Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: MW
-
-Maximum Active power|Electricity|Biomass|New and imported:
-   description: Maximum active power of one typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: MW
-
-Maximum Active power|Electricity|Nuclear:
-   description: Maximum active power of one typical nuclear power plant
-   unit: MW
-
-Maximum Active power|Electricity|Gas|OCGT:
-   description: Maximum active power of one typical Open Cycle Gas Turbine power plant
-   unit: MW
-
-Maximum Active power|Electricity|Gas|OCGT:
-   description: Maximum active power of one typical Combined Cycle Gas Turbine power plant
-   unit: MW
-
-Maximum Active power|Electricity|Coal:
-   description: Maximum active power of one typical coal power plant
-   unit: MW
-
-Maximum Active power|Electricity|Lignite:
-   description: Maximum active power of one typical Lignite power plant
-   unit: MW
-
-Minimum Active power|Electricity|Biomass|Traditionnal:
-   description: Minimum active power of one typical Traditionnal Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: MW
-
-Minimum Active power|Electricity|Biomass|New and imported :
-   description: Minimum active power of one typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: MW
-
-Minimum Active power|Electricity|Nuclear:
-   description: Minimum active power of one typical nuclear power plant
-   unit: MW
-
-Minimum Active power|Electricity|Gas|OCGT:
-   description: Minimum active power of one typical Open Cycle Gas Turbine power plant
-   unit: MW
-
-Minimum Active power|Electricity|Gas|CCGT:
-   description: Minimum active power of one typical Combined Cycle Gas Turbine power plant
-   unit: MW
-
-Minimum Active power|Electricity|Coal:
-   description: Minimum active power of one typical coal power plant
-   unit: MW
-
-Minimum Active power|Electricity|Lignite:
-   description: Minimum active power of one typical Lignite power plant
-   unit: MW
-
-Minimum On Duration|Electricity|Biomass|Traditionnal:
-   description: Minimum duration that the unit has to stay on when started, for one typical Traditionnal Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: hour
-
-Minimum On Duration|Electricity|Biomass|New and imported :
-   description: Minimum duration that the unit has to stay on when started, for one typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: hour
-
-Minimum On Duration|Electricity|Nuclear:
-   description: Minimum duration that the unit has to stay on when started, for one typical nuclear power plant
-   unit: hour
-
-Minimum On Duration|Electricity|Gas|OCGT:
-   description: Minimum duration that the unit has to stay on when started, for one typical Open Cycle Gas Turbine power plant
-   unit: hour
-
-Minimum On Duration|Electricity|Coal:
-   description: Minimum duration that the unit has to stay on when started, for one typical coal power plant
-   unit: hour
-
-Minimum On Duration|Electricity|Lignite:
-   description: Minimum duration that the unit has to stay on when started, for one typical Lignite power plant
-   unit: hour
-
-Minimum Off Duration|Electricity|Biomass|Traditionnal:
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical Traditionnal Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: hour
-
-Minimum Off Duration|Electricity|Biomass|New and imported :
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: hour
-
-Minimum Off Duration|Electricity|Nuclear:
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical nuclear power plant
-   unit: hour
-
-Minimum Off Duration|Electricity|Gas|OCGT:
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical Open Cycle Gas Turbine power plant
-   unit: hour
-
-Minimum Off Duration|Electricity|Coal:
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical coal power plant
-   unit: hour
-
-Minimum Off Duration|Electricity|Lignite:
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical Lignite power plant
-   unit: hour
-
-Forced Outage Rate|Electricity|Biomass|Traditionnal:
-   description: Unavailability Rate due to failures of typical Traditionnal Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: "%"
-
-Forced Outage Rate|Electricity|Biomass|New and imported :
-   description: Unavailability Rate due to failures of typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: "%"
-
-Forced Outage Rate|Electricity|Nuclear:
-   description: Unavailability Rate due to failures of typical nuclear power plant
-   unit: "%"
-
-Forced Outage Rate|Electricity|Gas|OCGT:
-   description: Unavailability Rate due to failures of typical Open Cycle Gas Turbine power plant
-   unit: "%"
-
-Forced Outage Rate|Electricity|Coal:
-   description: Unavailability Rate due to failures of typical coal power plant
-   unit: "%"
-
-Forced Outage Rate|Electricity|Lignite:
-   description: Unavailability Rate due to failures of typical Lignite power plant
-   unit: "%"
-
-Planned Outage Rate|Electricity|Biomass|Traditionnal:
-   description: Unavailability Rate due to maintenance of typical Traditionnal Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: "%"
-
-Planned Outage Rate|Electricity|Biomass|New and imported :
-   description: Unavailability Rate due to maintenance of typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: "%"
-
-Planned Outage Rate|Electricity|Nuclear:
-   description: Unavailability Rate due to maintenance of typical nuclear power plant
-   unit: "%"
-
-Planned Outage Rate|Electricity|Gas|OCGT:
-   description: Unavailability Rate due to maintenance of typical Open Cycle Gas Turbine power plant
-   unit: "%"
-
-Planned Outage Rate|Electricity|Coal:
-   description: Unavailability Rate due to maintenance of typical coal power plant
-   unit: "%"
-
-Planned Outage Rate|Electricity|Lignite:
-   description: Unavailability Rate due to maintenance of typical Lignite power plant
-   unit: "%"
-
-Mean Outage Duration|Electricity|Biomass|Traditionnal:
-   description: Mean duration of outages for a typical Traditionnal Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: "%"
-
-Mean Outage Duration|Electricity|Biomass|New and imported :
-   description: Mean duration of outages for a typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: "%"
-
-Mean Outage Duration|Electricity|Nuclear:
-   description: Mean duration of outages for a typical nuclear power plant
-   unit: "%"
-
-Mean Outage Duration|Electricity|Gas|OCGT:
-   description: Mean duration of outages for a typical Open Cycle Gas Turbine power plant
-   unit: "%"
-
-Mean Outage Duration|Electricity|Coal:
-   description: Mean duration of outages for a typical coal power plant
-   unit: "%"
-
-Mean Outage Duration|Electricity|Lignite:
-   description: Mean duration of outages for a typical Lignite power plant
-   unit: "%"
-
-Inertia|Electricity|Biomass|Traditionnal:
-   description: inertia privided to the system when started by a typical Traditionnal Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: second
-
-Inertia|Electricity|Biomass|New and imported :
-   description: inertia privided to the system when started by a typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: second
-
-Inertia|Electricity|Nuclear:
-   description: inertia privided to the system when started by a typical nuclear power plant
-   unit: second
-
-Inertia|Electricity|Gas|OCGT:
-   description: inertia privided to the system when started by a typical Open Cycle Gas Turbine power plant
-   unit: second
-
-Inertia|Electricity|Coal:
-   description: inertia privided to the system when started by a typical coal power plant
-   unit: second
-
-Inertia|Electricity|Lignite:
-   description: inertia privided to the system when started by a typical Lignite power plant
-   unit: second
-
-Rate Frequency Containment Reserve|Electricity|Biomass|Traditionnal:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical Traditionnal Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: "%"
-
-Rate Frequency Containment Reserve|Electricity|Biomass|New and imported :
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: "%"
-
-Rate Frequency Containment Reserve|Electricity|Nuclear:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical nuclear power plant
-   unit: "%"
-
-Rate Frequency Containment Reserve|Electricity|Gas|OCGT:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical Open Cycle Gas Turbine power plant
-   unit: "%"
-
-Rate Frequency Containment Reserve|Electricity|Coal:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical coal power plant
-   unit: "%"
-
-Rate Frequency Containment Reserve|Electricity|Lignite:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical Lignite power plant
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Biomass|Traditionnal:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical Traditionnal Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Biomass|New and imported :
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Nuclear:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical nuclear power plant
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Gas|OCGT:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical Open Cycle Gas Turbine power plant
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Coal:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical coal power plant
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Lignite:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical Lignite power plant
-   unit: "%"
-
-Operating Reserve|Down|Electricity|Coal:
-   description: Operating reserve down of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Down|Electricity|Gas:
-   description: Operating reserve down of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Down|Electricity|Nuclear:
-   description: Operating reserve down of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Down|Electricity|Oil:
-   description: Operating reserve down of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Up|Electricity|Coal:
-   description: Operating reserve up of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Up|Electricity|Gas:
-   description: Operating reserve up of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Up|Electricity|Nuclear:
-   description: Operating reserve up of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Up|Electricity|Oil:
-   description: Operating reserve up of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Maximum Ramping|Upwards|Electricity|Coal:
-   description: Upward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Upwards|Electricity|Gas:
-   description: Upward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Upwards|Electricity|Nuclear:
-   description: Upward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Upwards|Electricity|Oil:
-   description: Upward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Downwards|Electricity|Coal:
-   description: Downward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Downwards|Electricity|Gas:
-   description: Downward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Downwards|Electricity|Nuclear:
-   description: Downward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Downwards|Electricity|Oil:
-   description: Downward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-# description of simple hydrosystems - reservoir hydro
-# this describes systems composed of one reservoir and one plant (with potential pumping capacity) that are used for seasonal storage
-Number of Units|Electricity|Hydro|Reservoir:
-   description: Number of units of kind "simple Hydro reservoir "
-   unit:
-
-Maximum Active power|Electricity|Hydro|Reservoir:
-   description: Maximum active power of one typical "simple Hydro reservoir " unit
-   unit: MW
-
-Minimum Active power|Electricity|Hydro|Reservoir:
-   description: Minimum active power of one typical "simple Hydro reservoir " unit
-   unit: MW
-
-Maximum Storage|Electricity|Hydro|reservoir:
-   description: Maximum volume of a reservoir expressed in energy
+Operational Cost|Constant Term|Electricity Generation|<Fuel>:
+  description: Constant term (intercept) to compute operational cost
+    for generating electricity from <this fuel>
+  unit: Mcal/hour
+
+Operational Cost|Linear Term|Electricity Generation|<Fuel>:
+  description: Constant term (intercept) to compute operational cost
+    for generating electricity from <this fuel>
+  unit: Mcal/MWh
+
+Operation and Maintenance Cost|Electricity|<Fuel>:
+  description: Operation and maintenance cost for generating electricity
+    from <this fuel>
+  unit: EUR/MWh
+
+Shut-Down Cost|Electricity|<Fuel>:
+  description: Shutdown cost for a power plant generating electricity
+    from <this fuel>
+  unit: EUR
+
+Start-Up Cost|Electricity|<Fuel>:
+  description: Startup cost for a power plant generating electricity
+    from <this fuel>
+  unit: MEUR
+
+Variable Cost|Electricity|<Fuel>:
+  description: Variable cost for a power plant generating electricity
+    from <this fuel>
+  unit: EUR/MWh
+
+Number of Units|Electricity|<Fuel>:
+  description: Number of power plants units generating electricity
+    from <this fuel>
+  unit:
+
+Maximum Active Power|Electricity|<Fuel>:
+  description: Maximum active power of one typical power plant (unit)
+    generating electricity from <this fuel>
+  unit: MW
+
+Minimum Active Power|Electricity|<Fuel>:
+  description: Minimum active power of one typical plant (unit)
+    generating electricity from <this fuel>
+  unit: MW
+
+Minimum On Duration|Electricity|<Fuel>:
+  description: Minimum duration that one typical plant (unit) generating
+    electricity from <this fuel> has to remain online after startup
+  unit: hour
+
+Minimum Off Duration|Electricity|<Fuel>:
+  description: Minimum duration that one typical plant (unit) generating
+    electricity from <this fuel> has to remain offline after shutdown
+  unit: hour
+
+Forced Outage Rate|Electricity|<Fuel>:
+  description: Unavailability due to unplanned outages (e.g., failures)
+    for one typical plant (unit) generating electricity from <this fuel>
+  unit: "%"
+
+Planned Outage Rate|Electricity|<Fuel>:
+  description: Unavailability due to planned outages (e.g., maintainance)
+    for one typical plant (unit) generating electricity from <this fuel>
+  unit: "%"
+
+Mean Outage Duration|Electricity|<Fuel>:
+  description: Mean duration of an outage for one typical plant (unit)
+    generating electricity from <this fuel>
+  unit: "%"
+
+Inertia|Electricity|<Fuel>:
+  description: Inertia provided to the system by one typical plant (unit)
+    generating electricity from <this fuel>
+  unit: second
+
+Rate Frequency Containment Reserve|Electricity|<Fuel>:
+  description: Share of 'Maximum Active Power' that can be allocated to
+    Frequency Containment Reserve (FCR) by one typical plant (unit)
+    generating electricity from <this fuel>
+  unit: "%"
+
+Rate Automatic Frequency Restoration Reserve|Electricity|<Fuel>:
+  description: Share of 'Maximum Active Power' that can be allocated to
+    Automatic Frequency Containment Reserve (AFCR) by one typical plant (unit)
+    generating electricity from <this fuel>
+  unit: "%"
+
+Operating Reserve|Up|Electricity|<Fuel>:
+  description: Upward operating reserve (capacity) that can be provided
+    by one typical plant (unit) generating electricity from <this fuel>
+  unit: MWh
+
+Operating Reserve|Down|Electricity|<Fuel>:
+  description: Downward operating reserve (capacity) that can be provided
+    by one typical plant (unit) generating electricity from <this fuel>
+  unit: MWh
+
+Maximum Ramping|Up|Electricity|<Fuel>:
+  description: Upward ramp limit of one typical plant (unit)
+    generating electricity from <this fuel>
+  unit: MW/h
+
+Maximum Ramping|Down|Electricity|<Fuel>:
+  description: Downward ramp limit of one typical plant (unit)
+    generating electricity from <this fuel>
+  unit: MW/h
+
+# specific variables for reservoir hydro power plants
+Maximum Storage|Electricity|Hydro|Reservoir:
+   description: Maximum volume of a reservoir expressed in terms of energy
    unit: MWh
 
 Minimum Storage|Electricity|Hydro|Reservoir:
-   description: Minimum volume of a reservoir expressed in energy
+   description: Minimum volume of a reservoir expressed in terms of energy
    unit: MWh
 
 Pumping Efficiency|Electricity|Hydro|Reservoir:
-   description: efficiency of pumping for a reservoir power plant
+   description: Pumping efficiency for a reservoir power plant
    unit: "%"
 
-Inertia|Electricity|Hydro|Reservoir:
-   description: inertia provided to the system by a typical "simple Hydro reservoir " unit
-   unit: second
-
 Inflows|Electricity|Hydro|Reservoir:
-   description: hydraulic inflows to a reservoir expressed in energy
+   description: Hydraulic inflows to a reservoir expressed in energy
    unit: MWh
 
 Inflows|Electricity|Hydro|Reservoir|Profile:
-   description: Time serie of hydraulic inflows to a reservoir expressed in energy
+   description: Hydraulic inflows to a reservoir expressed in energy
    unit: MWh
 
-# description of simple hydrosystems -  pumped storage
-# this describes systems composed of one small reservoir and one plant with  pumping capacity that are used for short-term storage (eg week or day)
-Number of Units|Electricity|Hydro|Pumped Storage:
-   description: Number of units of kind "Pumped Storage "
-   unit:
-
-Maximum Active Power|Electricity|Hydro|Pumped Storage:
-   description: Maximum active power of one  "Pumped Storage " unit
-   unit: MW
-
-Minimum Active power|Electricity|Hydro|Pumped Storage:
-   description: Minimum active power of one  "Pumped Storage" unit
-   unit: MW
-
+# specific variables for pumped storage hydro power plants
 Maximum Storage|Electricity|Hydro|Pumped Storage:
-   description: Maximum volume of a Pumped Storage expressed in energy
+   description: Maximum volume of a pumped storage system
+     expressed in terms of energy
    unit: MWh
 
 Minimum Storage|Electricity|Hydro|Pumped Storage:
-   description: Minimum volume of a Pumped Storage expressed in energy
-   unit: MWh
+  description: Minimum volume of a pumped storage system
+    expressed in terms of energy
+  unit: MWh
 
 Pumping Efficiency|Electricity|Hydro|Pumped Storage:
-   description: efficiency of pumping for a Pumped Storage
+   description: Pumping efficiency for a reservoir power plant
    unit: "%"
 
-Inertia|Electricity|Hydro|Pumped Storage:
-   description: inertia provided to the system by a Pumped Storage unit
-   unit: second
-
-Rate Frequency Containment Reserve|Electricity|Hydro|Pumped Storage:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a Pumped Storage unit
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Hydro|Reservoir:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a Pumped Storage unit
-   unit: "%"
-
-# description of simple hydrosystems -  run of river
-# this describes systems composed of one run of river plant (without storage)
-Number of Units|Electricity|Hydro|Run of River:
-   description: Number of units of kind "Run of River"
-   unit:
-
-Maximum Active power|Electricity|Hydro|Run of River:
-   description: Maximum active power of one  "Run of River" unit
-   unit: MW
-
-LoadFactor|Electricity|Hydro|Run of River|Profile:
-   description: Timeserie of hourly loadfactors for  "Run of River"
-   unit: "%"
-
-Minimum Active power|Electricity|Hydro|Run of River:
-   description: Minimum active power of one  "Run of River" unit
-   unit: MW
-
-Inertia|Electricity|Hydro|Reservoir:
-   description: inertia provided to the system by a typical "simple Hydro reservoir " unit
-   unit: second
-
-Rate Frequency Containment Reserve|Electricity|Hydro|Reservoir:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical "simple Hydro reservoir " unit
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Hydro|Reservoir:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical "simple Hydro reservoir " unit
+# specific variables for run-of-river hydro power plants
+Load Factor|Electricity|Hydro|Run of River|Profile:
+   description: Load of hourly loadfactors for "Run of River"
    unit: "%"
 
 # description of Energy Storage Systems
@@ -675,94 +190,16 @@ Stored Energy Inventory|Electricity|Energy Storage System:
    unit:  GWh
 
 # description of PV power plants
-Number of Units|Electricity|Solar:
-   description: Number of units of kind Photovoltaic power plant
-   unit:
-
-Maximum Active power|Electricity|Solar:
-   description: Maximum active power of one Photovoltaic power plant
-   unit: MW
-
-LoadFactor|Electricity|Solar|Profile:
+Load Factor|Electricity|Solar|Profile:
    description: Timeserie of hourly loadfactors for Photovoltaic power plants
    unit: "%"
 
-Minimum Active power|Electricity|Solar:
-   description: Minimum active power of one Photovoltaic power plant
-   unit: MW
-
-Inertia|Electricity|Solar:
-   description: inertia provided to the system by a Photovoltaic power plant
-   unit: second
-
-Rate Frequency Containment Reserve|Electricity|Solar:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a Photovoltaic power plant
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Solar:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a Photovoltaic power plant
-   unit: "%"
-
 # description of Wind Onshore power plants
-Number of Units|Electricity|Wind|OnShore:
-   description: Number of units of kind Wind Onshore power plant
-   unit:
-
-Maximum Active power|Electricity|Wind|OnShore:
-   description: Maximum active power of one Wind Onshore power plant
-   unit: MW
-
-LoadFactor|Electricity|Wind|OnShore|Profile:
+Load Factor|Electricity|Wind|Onshore|Profile:
    description: Timeserie of hourly loadfactors for Onshore Windpower
    unit: "%"
 
-Minimum Active power|Electricity|Wind|OnShore:
-   description: Minimum active power of one Wind Onshore power plant
-   unit: MW
-
-Inertia|Electricity|Wind|OnShore:
-   description: inertia provided to the system by a Wind Onshore power plant
-   unit: second
-
-Rate Frequency Containment Reserve|Electricity|Wind|OnShore:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a Wind Onshore power plant
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Wind|OnShore:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a Wind Onshore power plant
-   unit: "%"
-
 # description of Wind Offshore power plants
-Number of Units|Electricity|Wind|OffShore:
-   description: Number of units of kind Wind OffShore power plant
-   unit:
-
-Maximum Active power|Electricity|Wind|OffShore:
-   description: Maximum active power of one Wind OffShore power plant
-   unit: MW
-
-LoadFactor|Electricity|Wind|OffShore|Profile:
+Load Factor|Electricity|Wind|OffShore|Profile:
    description: Timeserie of hourly loadfactors for Offshore Windpower
-   unit: "%"
-
-Minimum Active power|Electricity|Wind|OffShore:
-   description: Minimum active power of one Wind OffShore power plant
-   unit: MW
-
-Inertia|Electricity|Wind|OffShore:
-   description: inertia provided to the system by a Wind OffShore power plant
-   unit: second
-
-Rate Frequency Containment Reserve|Electricity|Wind|OffShore:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a Wind OffShore power plant
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Wind|OffShore:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a Wind OffShore power plant
    unit: "%"

--- a/nomenclature/definitions/variable/technology/power-plant.yaml
+++ b/nomenclature/definitions/variable/technology/power-plant.yaml
@@ -149,7 +149,7 @@ Pumping Efficiency|Electricity|Hydro|Pumped Storage:
 
 # specific variables for run-of-river hydro power plants
 Load Factor|Electricity|Hydro|Run of River|Profile:
-   description: Load of hourly loadfactors for "Run of River"
+   description: Load of hourly load factors for "Run of River"
    unit: "%"
 
 # description of Energy Storage Systems
@@ -191,15 +191,15 @@ Stored Energy Inventory|Electricity|Energy Storage System:
 
 # description of PV power plants
 Load Factor|Electricity|Solar|Profile:
-   description: Timeserie of hourly loadfactors for Photovoltaic power plants
+   description: Timeseries of hourly load factors for Photovoltaic power plants
    unit: "%"
 
 # description of Wind Onshore power plants
 Load Factor|Electricity|Wind|Onshore|Profile:
-   description: Timeserie of hourly loadfactors for Onshore Windpower
+   description: Timeseries of hourly load factors for Wind Onshore power plants
    unit: "%"
 
 # description of Wind Offshore power plants
 Load Factor|Electricity|Wind|OffShore|Profile:
-   description: Timeserie of hourly loadfactors for Offshore Windpower
+   description: Timeseries of hourly load factors for Wind Offshore power plants
    unit: "%"


### PR DESCRIPTION
This PR implements the refactoring of the fuel-type list (implemented for electricity at the secondary-energy level, see #64) for the variables representing characteristics of power plants.

A few clarifications are needed to finalize this:

 - Are we ok that there are multiple variables for operational cost
   - `Operational Cost|Constant Term|...`
   - `Operational Cost|Linear Term|...`
   - `Operation and Maintenance Cost|...`
  What are the differences?
 - Are we fine with the variables `Rate Frequency Containment Reserve` and `Rate Automatic Frequency Containment Reserve`, or should we drop the `Rate`?
 - Profile is defined in energy terms for hydro-reservoir inflow but as percentage (of what?) for other renewables... We should harmonize this before starting to use this.
 - What is meant with "Energy Storage System" - battery? compressed air?