### PR TITLE
Addition of Spanish super-grids from ehighway2050

### DIFF
--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -5,7 +5,7 @@
 # refer to `nuts1.yaml`, `nuts2.yaml`, `nuts3.yaml` for the definition of nuts regions
 
 # e-highway2050 clusters
-# e-highway2050 is a EU-funded project (2012-2015) whose objective was to provide a 
+# e-highway2050 is a EU-funded project (2012-2015) whose objective was to provide a
 # modular and robust expansion plan for the Pan-European Transmission Network from 2020 to 2050
 # In particular it defined a cluster model of the Pan-European transmission grid  (D2.2)
 # See https://docs.entsoe.eu/baltic-conf/bites/www.e-highway2050.eu/e-highway2050/
@@ -22,68 +22,68 @@ France|Subgrid 14:
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 14_FR
- 
+
 France|Subgrid 15:
   definition: FRJ22 + FRJ25 + FR627
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 15_FR
-    
+
 France|Subgrid 16:
   definition: FRL01 + FRL03 + FR824
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 16_FR
-  
+
 France|Subgrid 17:
   definition: FRG02 + FRG04 + FR515
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 17_FR
-  
+
 France|Subgrid 18:
   definition: FRB02 + FRB05 + FR246
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 18_FR
- 
-France|Subgrid 19:  
+
+France|Subgrid 19:
   definition: FRK22 + FRK23 + FR715
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 19_FR
-  
+
 France|Subgrid 20:
   definition: FRC22 + FRK21 + FRK24 + FRK27 + FRK28 + FRL02
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 20_FR
-  
+
 France|Subgrid 21:
   definition: FRG01 + FRG03 + FR521
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 21_FR
-  
+
 France|Subgrid 22:
   definition: FRD21 + FRD11 + FR252
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 22_FR
-  
+
 France|Subgrid 23:
   definition: FR101 + FR102 + FR103 + FR104 + FR105 + FR106 + FR107 + FR108
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 23_FR
-  
+
 France|Subgrid 24:
   definition: FRF22 + FRF24 + FRC11 + FRC13 + FRC14
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 24_FR
-  
-France|Subgrid 25:  
+
+France|Subgrid 25:
   definition: FRF31 + FRF32 + FRF33 + FRF34 + FRF11 + FRF12 + FRC21 + FRC23 + FRC24
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
@@ -100,96 +100,163 @@ France|Subgrid 27:
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 27_FR
-  
+
 France|Subgrid 99:
   definition: FRM01 + FRM02
   country: France
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 99_FR
-  
+
 # ehighway clusters Germany
-Germany|Subgrid 31:  
+Germany|Subgrid 31:
   definition: DE501 + DE502 + DE600 + DE911 + DE912 + DE913 + DE914 + DE916 + DE917 + DE918 + DE91A + DE91B + DE91C + DE922 + DE923 + DE925 + DE926 + DE927 + DE928 + DE929 + DE931 + DE932 + DE933 + DE934 + DE935 + DE936 + DE937 + DE938 + DE939 + DE93A + DE93B + DE941 + DE942 + DE943 + DE944 + DE945 + DE946 + DE947 + DE948 + DE949 + DE94A + DE94B + DE94C + DE94D + DE94E + DE94F + DE94G + DE94H + DEF01 + DEF02 + DEF03 + DEF04 + DEF05 + DEF06 + DEF07 + DEF08 + DEF09 + DEF0A + DEF0B + DEF0C + DEF0D + DEF0E + DEF0F + DEF0F
   country: Germany
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 31_DE
-  
-Germany|Subgrid 32:  
+
+Germany|Subgrid 32:
   definition: DE300 + DE401 + DE403 + DE404 + DE405 + DE406 + DE408 + DE409 + DE40A + DE40C + DE40D + DE40E + DE40F + DE40H + DE40I + DE803 + DE804 + DE80J + DE80K + DE80L + DE80M + DE80N + DE80O + DEE03 + DEE04 + DEE06 + DEE07 + DEE0D
   country: Germany
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 32_DE
-  
-Germany|Subgrid 33: 
+
+Germany|Subgrid 33:
   definition: DEA11 + DEA12 + DEA13 + DEA14 + DEA15 + DEA16 + DEA17 + DEA18 + DEA19 + DEA1A + DEA1B + DEA1C + DEA1D + DEA1E + DEA1F + DEA22 + DEA23 + DEA24 + DEA26 + DEA27 + DEA28 + DEA29 + DEA2A + DEA2B + DEA2C + DEA2D + DEA31 + DEA32 + DEA33 + DEA34 + DEA35 + DEA36 + DEA37 + DEA38 + DEA41 + DEA42 + DEA43 + DEA44 + DEA45 + DEA46 + DEA47 + DEA51 + DEA52 + DEA53 + DEA54 + DEA55 + DEA56 + DEA57 + DEA58 + DEA59 + DEA5A + DEA5B + DEA5C
   country: Germany
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 33_DE
-  
-Germany|Subgrid 34:  
+
+Germany|Subgrid 34:
   definition: DE402 + DE407 + DE40B + DE40G + DED21 + DED2C + DED2D + DED2E + DED2F + DED41 + DED42 + DED43 + DED44 + DED45 + DED51 + DED52 + DED52 + DED53 + DEE01 + DEE02 + DEE05 + DEE08 + DEE09 + DEE0A + DEE0B + DEE0C + DEE0E + DEG01 + DEG02 + DEG03 + DEG04 + DEG05 + DEG06 + DEG07 + DEG09 + DEG0A + DEG0B + DEG0C + DEG0D + DEG0E + DEG0F + DEG0G + DEG0H + DEG0I + DEG0J + DEG0K + DEG0L + DEG0M + DEG0N + DEG0P
   country: Germany
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 34_DE
-  
+
 Germany|Subgrid 35:
   definition: DE711 + DE712 + DE713 + DE714 + DE715 + DE716 + DE717 + DE718 + DE719 + DE71A + DE71B + DE71C + DE71D + DE71E + DE721 + DE722 + DE723 + DE724 + DE725 + DE731 + DE732 + DE733 + DE734 + DE735 + DE736 + DE737 + DEB11 + DEB12 + DEB13 + DEB14 + DEB15 + DEB17 + DEB18 + DEB1A + DEB1B + DEB1C + DEB1D + DEB21 + DEB22 + DEB23 + DEB24 + DEB25 + DEB31 + DEB32 + DEB33 + DEB34 + DEB35 + DEB36 + DEB37 + DEB38 + DEB39 + DEB3A + DEB3B + DEB3C + DEB3D + DEB3E + DEB3F + DEB3G + DEB3H + DEB3I + DEB3J + DEB3K + DEC01 + DEC02 + DEC03 + DEC04 + DEC05 + DEC06
   country: Germany
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 35_DE
-  
-Germany|Subgrid 36:  
+
+Germany|Subgrid 36:
   definition: DE111 + DE112 + DE113 + DE114 + DE115 + DE116 + DE117 + DE118 + DE119 + DE11A + DE11B + DE11C + DE11D + DE121 + DE122 + DE123 + DE124 + DE125 + DE126 + DE127 + DE128 + DE129 + DE12A + DE12B + DE12C + DE131 + DE132 + DE133 + DE134 + DE135 + DE136 + DE137 + DE138 + DE139 + DE13A + DE141 + DE142 + DE143 + DE144 + DE145 + DE146 + DE147 + DE148 + DE149
   country: Germany
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 36_DE
-  
-Germany|Subgrid 37:  
+
+Germany|Subgrid 37:
   definition: DE211 + DE212 + DE213 + DE214 + DE215 + DE216 + DE217 + DE218 + DE219 + DE21A + DE21B + DE21C + DE21D + DE21E + DE21F + DE21G + DE21H + DE21I + DE21J + DE21K + DE21L + DE21M + DE21N + DE221 + DE222 + DE223 + DE224 + DE225 + DE226 + DE227 + DE228 + DE229 + DE22A + DE22B + DE22C + DE231 + DE232 + DE233 + DE234 + DE235 + DE236 + DE237 + DE238 + DE239 + DE23A + DE241 + DE242 + DE243 + DE244 + DE245 + DE246 + DE247 + DE248 + DE249 + DE24A + DE24B + DE24C + DE24D + DE251 + DE252 + DE253 + DE254 + DE255 + DE256 + DE257 + DE258 + DE259 + DE25A + DE25B + DE25C + DE261 + DE262 + DE263 + DE264 + DE265 + DE266 + DE267 + DE268 + DE269 + DE26A + DE26B + DE26C + DE271 + DE272 + DE273 + DE274 + DE275 + DE276 + DE277 + DE278 + DE279 + DE27A + DE27B + DE27C + DE27D + DE27E
   country: Germany
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 37_DE
 
 # ehighway clusters Italy
-Italy|Subgrid 52:  
+Italy|Subgrid 52:
   definition: ITC11 + ITC12 + ITC13 + ITC14 + ITC15 + ITC16 + ITC17 + ITC18 + ITC20 + ITC31 + ITC32 + ITC33 + ITC34 + ITC41 + ITC42 + ITC43 + ITC44 + ITC46 + ITC47 + ITC48 + ITC49 + ITC4A + ITC4B + ITC4C + ITC4D + ITH10 + ITH20 + ITH31 + ITH32 + ITH33 + ITH34 + ITH35 + ITH36 + ITH37 + ITH41 + ITH42 + ITH43 + ITH44 + ITH51 + ITH52 + ITH53 + ITH54 + ITH55 + ITH56 + ITH57 + ITH58 + ITH59
   country: Italy
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 52_IT
 
-Italy|Subgrid 53:  
+Italy|Subgrid 53:
   definition: ITI11 + ITI12 + ITI13 + ITI14 + ITI15 + ITI16 + ITI17 + ITI18 + ITI19 + ITI1A + ITI21 + ITI22 + ITI31 + ITI32 + ITI33 + ITI34 + ITI35
   country: Italy
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 53_IT
 
-Italy|Subgrid 54:  
+Italy|Subgrid 54:
   definition: ITI41 + ITI42 + ITI43 + ITI44 + ITI45 + ITF11 + ITF12 + ITF13 + ITF14 + ITF31 + ITF32 + ITF33 + ITF34 + ITF35
   country: Italy
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 54_IT
-  
-Italy|Subgrid 55:  
+
+Italy|Subgrid 55:
   definition: ITF21 + ITF22 + ITF43 + ITF44 + ITF45 + ITF46 + ITF47 + ITF48 + ITF51 + ITF52 + ITF61 + ITF62 + ITF63 + ITF64 + ITF65
   country: Italy
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 55_IT
-  
-Italy|Subgrid 56:  
+
+Italy|Subgrid 56:
   definition: ITG11 + ITG12 + ITG13 + ITG14 + ITG15 + ITG16 + ITG17 + ITG18 + ITG19
   country: Italy
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 56_IT
-  
-Italy|Subgrid 98:  
+
+Italy|Subgrid 98:
   definition: ITG2D + ITG2E + ITG2F + ITG2G + ITG2H
   country: Italy
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 98_IT
+
+# ehighway clusters Spain
+Spain|Subgrid 01:
+  definition: ES111 + ES112 + ES113 + ES114
+  country: Spain
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 01_ES
+
+Spain|Subgrid 02:
+  definition: ES120 + ES130 + ES413 + ES415 + ES419
+  country: Spain
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 02_ES
+
+Spain|Subgrid 03:
+  definition: ES411 + ES412 + ES414 + ES416 + ES417 + ES418 + ES424
+  country: Spain
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 03_ES
+
+Spain|Subgrid 04:
+  definition: ES211 +ES212 + ES213 + ES220 + ES230
+  country: Spain
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 04_ES
+
+Spain|Subgrid 05:
+  definition: ES241 + ES242 + ES243
+  country: Spain
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 05_ES
+
+Spain|Subgrid 06:
+  definition: ES511 + ES512 + ES513 + ES514
+  country: Spain
+  ehighway2050: 06_ES
+  note: This region was defined and used in the ehighway2050 public datasets
+
+Spain|Subgrid 07:
+  definition: ES300
+  country: Spain
+  ehighway2050: 07_ES
+  note: This region was defined and used in the ehighway2050 public datasets
+
+Spain|Subgrid 08:
+  definition: ES422 + ES425 + ES431 + ES432
+  country: Spain
+  ehighway2050: 08_ES
+  note: This region was defined and used in the ehighway2050 public datasets
+
+Spain|Subgrid 09:
+  definition: ES612 + ES615 + ES617 + ES618
+  country: Spain
+  ehighway2050: 09_ES
+  note: This region was defined and used in the ehighway2050 public datasets
+
+Spain|Subgrid 10:
+  definition: ES611 + ES613 + ES614 + ES616
+  country: Spain
+  ehighway2050: 10_ES
+  note: This region was defined and used in the ehighway2050 public datasets
+
+Spain|Subgrid 11:
+  definition: ES421 + ES423 + ES521 + ES522 + ES523 + ES620
+  country: Spain
+  ehighway2050: 11_ES
+  note: This region was defined and used in the ehighway2050 public datasets
   
 # Aggregation of ehighway clusters in larger subcountry regions
 
-# Aggregation of ehighway clusters for Italy 
+# Aggregation of ehighway clusters for Italy
 # ITN and ITS are the codes used in the plan4res public dataset; ITN+ITS=IT
 # We could use syniminms : ITN=Northern Italy and ITS=Southern Italy
 Italy|Subgrid north:
@@ -198,38 +265,38 @@ Italy|Subgrid north:
   note: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions; ITN+ITS=IT
   ehighway2050: 52_IT + 53_IT
   plan4res: ITN
-  
-Italy|Subgrid south: 
-  definition: Italy|Subgrid 54 + Italy|Subgrid 55 + Italy|Subgrid 56 + Italy|Subgrid 98 
+
+Italy|Subgrid south:
+  definition: Italy|Subgrid 54 + Italy|Subgrid 55 + Italy|Subgrid 56 + Italy|Subgrid 98
   country: Italy
   note: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions; ITN+ITS=IT
   ehighway2050: 54_IT + 55_IT + 56_IT + 98_IT
   plan4res: ITS
-  
+
 # ehighway north sea clusters
-Belgium|North Sea: 
-    definition: this 'virtual' region holds the offshore windpower of belgium in norh sea 
+Belgium|North Sea:
+    definition: this 'virtual' region holds the offshore windpower of belgium in norh sea
     country: Belgium
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 110_NS
     plan4res: NSBE
-    
-Germany|North Sea: 
-    definition: this 'virtual' region holds the offshore windpower of germany in norh sea 
+
+Germany|North Sea:
+    definition: this 'virtual' region holds the offshore windpower of germany in norh sea
     country: Germany
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 112_NS
     plan4res: NSDE
 
-The Netherlands|North Sea: 
-    definition: this 'virtual' region holds the offshore windpower of the netherlands in norh sea 
+The Netherlands|North Sea:
+    definition: this 'virtual' region holds the offshore windpower of the netherlands in norh sea
     country: The Netherlands
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 111_NS
     plan4res: NSNL
-    
-United Kingdom|North Sea: 
-    definition: this 'virtual' region holds the offshore windpower of the UK in norh sea 
+
+United Kingdom|North Sea:
+    definition: this 'virtual' region holds the offshore windpower of the UK in norh sea
     country: United Kingdom
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 106_NS+107_NS+108_NS+109_NS


### PR DESCRIPTION
This PR adds Spanish regions that were defined and used in the ehighway2050 public datasets