### PR TITLE
Refactoring and simplifying of variables related to power plant specifications

### DIFF
--- a/nomenclature/definitions/variable/technology/power-plant.yaml
+++ b/nomenclature/definitions/variable/technology/power-plant.yaml
@@ -3,571 +3,106 @@
 # Note that:
 # linear   term cost   [EUR/GWh] = Linear Var Cost [Mcal/MWh] * Price|Primary Energy [EUR/Mcal] + Operation and Maintenance Variable Cost [EUR/MWh] * 1e-3
 # constant term cost   [EUR/h]   = Constant Var Cost [Mcal/h] * Price|Primary Energy [EUR/Mcal]
-Operational Cost|Constant Term|Electricity Generation|Coal:
-   description: Constant term (intercept) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the unit commitment variable of each power plant per unit time.
-   unit: Mcal/hour
-
-Operational Cost|Constant Term|Electricity Generation|Gas:
-   description: Constant term (intercept) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the unit commitment variable of each power plant per unit time.
-   unit: Mcal/hour
-
-Operational Cost|Constant Term|Electricity Generation|Nuclear:
-   description: Constant term (intercept) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the unit commitment variable of each power plant per unit time.
-   unit: Mcal/hour
-
-Operational Cost|Constant Term|Electricity Generation|Oil:
-   description: Constant term (intercept) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the unit commitment variable of each power plant per unit time.
-   unit: Mcal/hour
-
-Operational Cost|Linear Term|Electricity Generation|Coal:
-   description: Linear term (slope) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the production cost of each energy unit (GWh, MWh,etc.).
-   unit: Mcal/MWh
-
-Operational Cost|Linear Term|Electricity Generation|Gas:
-   description: Linear term (slope) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the production cost of each energy unit (GWh, MWh,etc.).
-   unit: Mcal/MWh
-
-Operational Cost|Linear Term|Electricity Generation|Nuclear:
-   description: Linear term (slope) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the production cost of each energy unit (GWh, MWh,etc.).
-   unit: Mcal/MWh
-
-Operational Cost|Linear Term|Electricity Generation|Oil:
-   description: Linear term (slope) of the heat rate straight line. Cost of the power generation unit who belongs to the specified power
-                plant category. It refers to the production cost of each energy unit (GWh, MWh,etc.).
-   unit: Mcal/MWh
-
-Operation and Maintenance Cost|Electricity|Coal:
-   description: Operation and maintenance cost of the power generation unit who belongs to the specified power
-                plant category.
-   unit: EUR/MWh
-
-Operation and Maintenance Cost|Electricity|Gas:
-   description: Operation and maintenance cost of the power generation unit who belongs to the specified power
-                plant category.
-   unit: EUR/MWh
-
-Operation and Maintenance Cost|Electricity|Nuclear:
-   description: Operation and maintenance cost of the power generation unit who belongs to the specified power
-                plant category.
-   unit: EUR/MWh
-
-Operation and Maintenance Cost|Electricity|Oil:
-   description: Operation and maintenance cost of the power generation unit who belongs to the specified power
-                plant category.
-   unit: EUR/MWh
-
-Shut-Down Cost|Electricity|Coal:
-   description: Shutdown heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Shut-Down Cost|Electricity|Gas:
-   description: Shutdown heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Shut-Down Cost|Electricity|Nuclear:
-   description: Shutdown heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Shut-Down Cost|Electricity|Oil:
-   description: Shutdown heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-Start-Up Cost|Electricity|Coal:
-   description: Startup heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Start-Up Cost|Electricity|Gas:
-   description: Startup heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Start-Up Cost|Electricity|Nuclear:
-   description: Startup heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Start-Up Cost|Electricity|Oil:
-   description: Startup heat cost per power generation unit who belongs to the specified power
-                plant category.
-   unit: MEUR
-
-Variable Cost|Electricity|Biomass|Traditionnal:
-   description: variable cost of a typical Traditionnal Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: EUR/MWh
-
-Variable Cost|Electricity|Biomass|New and imported :
-   description: variable cost of a typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: EUR/MWh
-
-Variable Cost|Electricity|Nuclear:
-   description: variable cost of a typical nuclear power plant
-   unit: EUR/MWh
-
-Variable Cost|Electricity|Gas|OCGT:
-   description: variable cost of a typical Open Cycle Gas Turbine power plant
-   unit: EUR/MWh
-   
-Variable Cost|Electricity|Gas|CCGT:
-   description: variable cost of a typical Combined Cycle Gas Turbine power plant
-   unit: EUR/MWh
-
-Variable Cost|Electricity|Coal:
-   description: variable cost of a typical coal power plant
-   unit: EUR/MWh
-
-Variable Cost|Electricity|Lignite:
-   description: variable cost of a typical Lignite power plant
-   unit: EUR/MWh
-
-# Variables related to thermal power plants
-Number of Units|Electricity|Biomass|Traditional:
-   description: number of units of kind "Traditional Biomass power plant "
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit:
-
-Number of Units|Electricity|Biomass|New and imported:
-   description: Number of units of kind "new biomass power plant "
-                biomass from dedicated energy crops and biomass imports.
-   unit:
-
-Number of Units|Electricity|Nuclear:
-   description: Number of units of kind "nuclear power plant "
-   unit:
-
-Number of Units|Electricity|Gas|OCGT:
-   description: Number of units of kind "Open Cycle Gas Turbine power plant"
-   unit:
-
-Number of Units|Electricity|Gas|CCGT:
-   description: Number of units of kind "Combined Cycle Gas Turbine power plant"
-   unit:
-   
-Number of Units|Electricity|Coal:
-   description: Number of units of kind "coal power plant "
-   unit:
-
-Number of Units|Electricity|Lignite:
-   description: Number of units of kind "Lignite power plant "
-   unit:
-   
-Maximum Active Power|Electricity|Biomass|Traditional:
-   description: Maximum active power of one typical Traditional Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: MW
-
-Maximum Active power|Electricity|Biomass|New and imported:
-   description: Maximum active power of one typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: MW
-
-Maximum Active power|Electricity|Nuclear:
-   description: Maximum active power of one typical nuclear power plant
-   unit: MW
-
-Maximum Active power|Electricity|Gas|OCGT:
-   description: Maximum active power of one typical Open Cycle Gas Turbine power plant
-   unit: MW
-
-Maximum Active power|Electricity|Gas|CCGT:
-   description: Maximum active power of one typical Combined Cycle Gas Turbine power plant
-   unit: MW
-
-Maximum Active power|Electricity|Coal:
-   description: Maximum active power of one typical coal power plant
-   unit: MW
-
-Maximum Active power|Electricity|Lignite:
-   description: Maximum active power of one typical Lignite power plant
-   unit: MW
-
-Minimum Active Power|Electricity|Biomass|Traditional:
-   description: Minimum active power of one typical Traditional Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: MW
-
-Minimum Active Power|Electricity|Biomass|New and imported:
-   description: Minimum active power of one typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: MW
-
-Minimum Active power|Electricity|Nuclear:
-   description: Minimum active power of one typical nuclear power plant
-   unit: MW
-
-Minimum Active power|Electricity|Gas|OCGT:
-   description: Minimum active power of one typical Open Cycle Gas Turbine power plant
-   unit: MW
-
-Minimum Active power|Electricity|Gas|CCGT:
-   description: Minimum active power of one typical Combined Cycle Gas Turbine power plant
-   unit: MW
-
-Minimum Active power|Electricity|Coal:
-   description: Minimum active power of one typical coal power plant
-   unit: MW
-
-Minimum Active power|Electricity|Lignite:
-   description: Minimum active power of one typical Lignite power plant
-   unit: MW
-
-Minimum On Duration|Electricity|Biomass|Traditional:
-   description: Minimum duration that the unit has to stay on when started, for one typical Traditional Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: hour
-
-Minimum On Duration|Electricity|Biomass|New and imported :
-   description: Minimum duration that the unit has to stay on when started, for one typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: hour
-
-Minimum On Duration|Electricity|Nuclear:
-   description: Minimum duration that the unit has to stay on when started, for one typical nuclear power plant
-   unit: hour
-
-Minimum On Duration|Electricity|Gas|OCGT:
-   description: Minimum duration that the unit has to stay on when started, for one typical Open Cycle Gas Turbine power plant
-   unit: hour
-   
-Minimum On Duration|Electricity|Gas|CCGT:
-   description: Minimum duration that the unit has to stay on when started, for one typical Combined Cycle Gas Turbine power plant
-   unit: hour
-
-Minimum On Duration|Electricity|Coal:
-   description: Minimum duration that the unit has to stay on when started, for one typical coal power plant
-   unit: hour
-
-Minimum On Duration|Electricity|Lignite:
-   description: Minimum duration that the unit has to stay on when started, for one typical Lignite power plant
-   unit: hour
-
-Minimum Off Duration|Electricity|Biomass|Traditional:
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical Traditional Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: hour
-
-Minimum Off Duration|Electricity|Biomass|New and imported :
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: hour
-
-Minimum Off Duration|Electricity|Nuclear:
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical nuclear power plant
-   unit: hour
-
-Minimum Off Duration|Electricity|Gas|OCGT:
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical Open Cycle Gas Turbine power plant
-   unit: hour
-   
-Minimum Off Duration|Electricity|Gas|CCGT:
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical Combined Cycle Gas Turbine power plant
-   unit: hour
-   
-Minimum Off Duration|Electricity|Coal:
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical coal power plant
-   unit: hour
-
-Minimum Off Duration|Electricity|Lignite:
-   description: Minimum duration that the unit has to stay off when shut-down, for one typical Lignite power plant
-   unit: hour
-
-Forced Outage Rate|Electricity|Biomass|Traditional:
-   description: Unavailability Rate due to failures of typical Traditional Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: "%"
-
-Forced Outage Rate|Electricity|Biomass|New and imported :
-   description: Unavailability Rate due to failures of typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: "%"
-
-Forced Outage Rate|Electricity|Nuclear:
-   description: Unavailability Rate due to failures of typical nuclear power plant
-   unit: "%"
-
-Forced Outage Rate|Electricity|Gas|OCGT:
-   description: Unavailability Rate due to failures of typical Open Cycle Gas Turbine power plant
-   unit: "%"
-   
-Forced Outage Rate|Electricity|Gas|CCGT:
-   description: Unavailability Rate due to failures of typical Combined Cycle Gas Turbine power plant
-   unit: "%"
-
-Forced Outage Rate|Electricity|Coal:
-   description: Unavailability Rate due to failures of typical coal power plant
-   unit: "%"
-
-Forced Outage Rate|Electricity|Lignite:
-   description: Unavailability Rate due to failures of typical Lignite power plant
-   unit: "%"
-
-Planned Outage Rate|Electricity|Biomass|Traditional:
-   description: Unavailability Rate due to maintenance of typical Traditional Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: "%"
-
-Planned Outage Rate|Electricity|Biomass|New and imported :
-   description: Unavailability Rate due to maintenance of typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: "%"
-
-Planned Outage Rate|Electricity|Nuclear:
-   description: Unavailability Rate due to maintenance of typical nuclear power plant
-   unit: "%"
-
-Planned Outage Rate|Electricity|Gas|OCGT:
-   description: Unavailability Rate due to maintenance of typical Open Cycle Gas Turbine power plant
-   unit: "%"
-   
-Planned Outage Rate|Electricity|Gas|CCGT:
-   description: Unavailability Rate due to maintenance of typical Combined Cycle Gas Turbine power plant
-   unit: "%"
-
-Planned Outage Rate|Electricity|Coal:
-   description: Unavailability Rate due to maintenance of typical coal power plant
-   unit: "%"
-
-Planned Outage Rate|Electricity|Lignite:
-   description: Unavailability Rate due to maintenance of typical Lignite power plant
-   unit: "%"
-
-Mean Outage Duration|Electricity|Biomass|Traditional:
-   description: Mean duration of outages for a typical Traditional Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: "%"
-
-Mean Outage Duration|Electricity|Biomass|New and imported :
-   description: Mean duration of outages for a typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: "%"
-
-Mean Outage Duration|Electricity|Nuclear:
-   description: Mean duration of outages for a typical nuclear power plant
-   unit: "%"
-
-Mean Outage Duration|Electricity|Gas|OCGT:
-   description: Mean duration of outages for a typical Open Cycle Gas Turbine power plant
-   unit: "%"
-   
-Mean Outage Duration|Electricity|Gas|CCGT:
-   description: Mean duration of outages for a typical Combined Cycle Gas Turbine power plant
-   unit: "%"
-
-Mean Outage Duration|Electricity|Coal:
-   description: Mean duration of outages for a typical coal power plant
-   unit: "%"
-
-Mean Outage Duration|Electricity|Lignite:
-   description: Mean duration of outages for a typical Lignite power plant
-   unit: "%"
-
-Inertia|Electricity|Biomass|Traditional:
-   description: inertia privided to the system when started by a typical Traditional Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: second
-
-Inertia|Electricity|Biomass|New and imported :
-   description: inertia privided to the system when started by a typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: second
-
-Inertia|Electricity|Nuclear:
-   description: inertia privided to the system when started by a typical nuclear power plant
-   unit: second
-
-Inertia|Electricity|Gas|OCGT:
-   description: inertia privided to the system when started by a typical Open Cycle Gas Turbine power plant
-   unit: second
-
-Inertia|Electricity|Gas|CCGT:
-   description: inertia privided to the system when started by a typical Combined Cycle Gas Turbine power plant
-   unit: second
-
-Inertia|Electricity|Coal:
-   description: inertia privided to the system when started by a typical coal power plant
-   unit: second
-
-Inertia|Electricity|Lignite:
-   description: inertia privided to the system when started by a typical Lignite power plant
-   unit: second
-
-Rate Frequency Containment Reserve|Electricity|Biomass|Traditional:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical Traditional Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: "%"
-
-Rate Frequency Containment Reserve|Electricity|Biomass|New and imported :
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: "%"
-
-Rate Frequency Containment Reserve|Electricity|Nuclear:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical nuclear power plant
-   unit: "%"
-
-Rate Frequency Containment Reserve|Electricity|Gas|OCGT:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical Open Cycle Gas Turbine power plant
-   unit: "%"
-   
-Rate Frequency Containment Reserve|Electricity|Gas|CCGT:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical Open Cycle Gas Turbine power plant
-   unit: "%"
-
-Rate Frequency Containment Reserve|Electricity|Coal:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical coal power plant
-   unit: "%"
-
-Rate Frequency Containment Reserve|Electricity|Lignite:
-   description: Percentage of the Maximum Active Power that can be devoted to Frequency Containment Reserve
-                for a typical Lignite power plant
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Biomass|Traditional:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical Traditional Biomass power plant
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Biomass|New and imported :
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical new biomass power plant
-                biomass from dedicated energy crops and biomass imports.
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Nuclear:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical nuclear power plant
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Gas|OCGT:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical Open Cycle Gas Turbine power plant
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Gas|CCGT:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical Open Cycle Gas Turbine power plant
-   unit: "%"
-   
-Rate Automatic Frequency Restoration Reserve|Electricity|Coal:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical coal power plant
-   unit: "%"
-
-Rate Automatic Frequency Restoration Reserve|Electricity|Lignite:
-   description: Percentage of the Maximum Active Power that can be devoted to Automatic Frequency Restoration Reserve
-                for a typical Lignite power plant
-   unit: "%"
-
-Operating Reserve|Down|Electricity|Coal:
-   description: Operating reserve down of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Down|Electricity|Gas:
-   description: Operating reserve down of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Down|Electricity|Nuclear:
-   description: Operating reserve down of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Down|Electricity|Oil:
-   description: Operating reserve down of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Up|Electricity|Coal:
-   description: Operating reserve up of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Up|Electricity|Gas:
-   description: Operating reserve up of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Up|Electricity|Nuclear:
-   description: Operating reserve up of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Operating Reserve|Up|Electricity|Oil:
-   description: Operating reserve up of a power generation unit who belongs to the specified power
-                plant category
-   unit: MWh
-
-Maximum Ramping|Upwards|Electricity|Coal:
-   description: Upward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Upwards|Electricity|Gas:
-   description: Upward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Upwards|Electricity|Nuclear:
-   description: Upward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Upwards|Electricity|Oil:
-   description: Upward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Downwards|Electricity|Coal:
-   description: Downward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Downwards|Electricity|Gas:
-   description: Downward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Downwards|Electricity|Nuclear:
-   description: Downward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
-
-Maximum Ramping|Downwards|Electricity|Oil:
-   description: Downward ramp limit of the power generation unit who belongs to the specified power
-                plant category.
-   unit: MW/h
+Operational Cost|Constant Term|Electricity Generation|<Fuel>:
+  description: Constant term (intercept) to compute operational cost
+    for generating electricity from <this fuel>
+  unit: Mcal/hour
+
+Operational Cost|Linear Term|Electricity Generation|<Fuel>:
+  description: Linear term (slope) to compute operational cost
+   for generating electricity from <this fuel>
+  unit: Mcal/MWh
+
+Operation and Maintenance Cost|Electricity|<Fuel>:
+  description: Operation and maintenance cost for generating electricity
+    from <this fuel>
+  unit: EUR/MWh
+
+Shut-Down Cost|Electricity|<Fuel>:
+  description: Shutdown cost for a typical power plant generating electricity
+    from <this fuel>
+  unit: EUR
+
+Start-Up Cost|Electricity|<Fuel>:
+  description: Startup cost for a typical power plant generating electricity
+    from <this fuel>
+  unit: EUR
+
+Variable Cost|Electricity|<Fuel>:
+  description: Variable cost for generating electricity from <this fuel>
+  unit: EUR/MWh
+
+Number of Units|Electricity|<Fuel>:
+  description: Number of power plant units generating electricity
+    from <this fuel>
+  unit:
+
+Maximum Active Power|Electricity|<Fuel>:
+  description: Maximum active power of a typical power plant
+    generating electricity from <this fuel>
+  unit: MW
+
+Minimum On Duration|Electricity|<Fuel>:
+  description: Minimum duration that a typical power plant generating
+    electricity from <this fuel> has to remain online after start-up
+  unit: hour
+
+Minimum Off Duration|Electricity|<Fuel>:
+  description: Minimum duration that a typical power plant generating
+    electricity from <this fuel> has to remain offline after shut-down
+  unit: hour
+
+Forced Outage Rate|Electricity|<Fuel>:
+  description: Unavailability due to unexpected outages (e.g., failures)
+    of a typical power plant generating electricity from <this fuel>
+  unit: "%"
+
+Planned Outage Rate|Electricity|<Fuel>:
+  description: Unavailability due to planned outages (e.g., maintaince,
+    revision) of a typical power plant generating electricity from <this fuel>
+  unit: "%"
+
+Mean Outage Duration|Electricity|<Fuel>:
+  description: Mean duration of an outage of a typical power plant generating
+    electricity from <this fuel>
+  unit: "%"
+
+Inertia|Electricity|<Fuel>:
+  description: Inertia provided to the system by a typical power plant
+    generating electricity from <this fuel>
+  unit: second
+
+Rate Frequency Containment Reserve|Electricity|<Fuel>:
+  description: Percentage of Maximum Active Power that can be committed to
+    Frequency Containment Reserve by a typical power plant
+    generating electricity from <this fuel>
+  unit: "%"
+
+Rate Automatic Frequency Restoration Reserve|Electricity|<Fuel>:
+  description: Percentage of Maximum Active Power that can be committed to
+    Automatic Frequency Restoration Reserve by a typical power plant
+    generating electricity from <this fuel>
+  unit: "%"
+
+Operating Reserve|Down|Electricity|<Fuel>:
+  description: Downward operating reserve by a typical power plant
+    generating electricity from <this fuel>
+  unit: MWh
+
+Operating Reserve|Up|Electricity|<Fuel>:
+  description: Upwards operating reserve by a typical power plant
+    generating electricity from <this fuel>
+  unit: MWh
+
+Maximum Ramping|Upwards|Electricity|<Fuel>:
+  description: Upward ramp limit by a typical power plant
+    generating electricity from <this fuel>
+  unit: MW/h
+
+Maximum Ramping|Downwards|Electricity|<Fuel>:
+  description: Downward ramp limit by a typical power plant
+    generating electricity from <this fuel>
+  unit: MW/h
 
 # description of simple hydrosystems - reservoir hydro
 # this describes systems composed of one reservoir and one plant (with potential pumping capacity) that are used for seasonal storage


### PR DESCRIPTION
This PR is a reimplementation of parts of the (stale) PR #67 - it simply refactors the definition of variables related to power plant specifications to use the shorthand-definition of `<Fuel>` rather than specifying all possible permutations of variables and technologies.

The questions raised in #67 will be discussed (again) in a subsequent PR.