### PR TITLE
Remove duplicate variable for hydro-reservoir inflow

### DIFF
--- a/nomenclature/definitions/variable/technology/power-plant.yaml
+++ b/nomenclature/definitions/variable/technology/power-plant.yaml
@@ -127,10 +127,6 @@ Inflows|Electricity|Hydro|Reservoir:
   description: Inflows into a reservoir expressed in energy
   unit: MWh
 
-Inflows|Electricity|Hydro|Reservoir|Profile:
-  description: Time serie of hydraulic inflows to a reservoir expressed in energy
-  unit: MWh
-
 Maximum Storage|Electricity|Hydro|Pumped Storage:
    description: Maximum volume of a Pumped Storage expressed in energy
    unit: MWh


### PR DESCRIPTION
In the current implementation, the variables `Inflows|Electricity|Hydro|Reservoir` and `Inflows|Electricity|Hydro|Reservoir|Profile` have the same unit, so in my understanding, they only differ with regard to the time duration to which they apply.

The first variable seems to be intended for yearly values, and the second is the hourly profile. I think that this could be more clearly communicated by using only one variable and clarifying the duration using the time domain of the data format.

 - If the column 'subannual' is empty (or 'Year'), the value associated with that variable is the total inflow in a year
 - If the column 'subannual' specifies a period, then the value associated with the variable is the total inflow in that period

Therefore, this PR suggests to remove the 'Profile'-version of the variable.

This would be the same approach the we use for similar variables like generation (it's the total generation over a time period, whether the time period is a full year or an hour).