### PR TITLE
Harmonize variable name for run-of-river-hydro load factor

### DIFF
--- a/nomenclature/definitions/variable/technology/power-plant.yaml
+++ b/nomenclature/definitions/variable/technology/power-plant.yaml
@@ -149,8 +149,8 @@ Turbine Efficiency|Electricity|Hydro|Pumped Storage:
 
 # description of simple hydrosystems -  run of river
 # this describes systems composed of one run of river plant (without storage)
-LoadFactor|Electricity|Hydro|Run of River|Profile:
-  description: Timeserie of hourly loadfactors for  "Run of River"
+Load Factor|Electricity|Hydro|Run of River:
+  description: Load factors for run-of-river power plants
   unit: '%'
 
 # description of Energy Storage Systems


### PR DESCRIPTION
This PR adds a space in the term "Load Factor" in line with the recommendation for variable naming. It also removes the "Profile" part from the variable name following the same logic as #92.