### PR TITLE
Remove `Rate` from variables relate to reserve

### DIFF
--- a/nomenclature/definitions/variable/technology/power-plant.yaml
+++ b/nomenclature/definitions/variable/technology/power-plant.yaml
@@ -72,14 +72,14 @@ Inertia|Electricity|<Fuel>:
     generating electricity from <this fuel>
   unit: second
 
-Rate Frequency Containment Reserve|Electricity|<Fuel>:
-  description: Percentage of Maximum Active Power that can be committed to
+Frequency Containment Reserve|Electricity|<Fuel>:
+  description: Share of Maximum Active Power that can be committed to
     Frequency Containment Reserve by a typical power plant
     generating electricity from <this fuel>
   unit: "%"
 
-Rate Automatic Frequency Restoration Reserve|Electricity|<Fuel>:
-  description: Percentage of Maximum Active Power that can be committed to
+Automatic Frequency Restoration Reserve|Electricity|<Fuel>:
+  description: Share of Maximum Active Power that can be committed to
     Automatic Frequency Restoration Reserve by a typical power plant
     generating electricity from <this fuel>
   unit: "%"


### PR DESCRIPTION
This PR removes the part "Rate" from the variables related to the reserve - the fact that this is a share of the maximum active power is indicated by the unit and the description, it doesn't need to repeated in the variable name.