### PR TITLE
Change unit of `Mean Outage Duration` to time domain

### DIFF
--- a/nomenclature/definitions/variable/technology/power-plant.yaml
+++ b/nomenclature/definitions/variable/technology/power-plant.yaml
@@ -65,7 +65,7 @@ Planned Outage Rate|Electricity|<Fuel>:
 Mean Outage Duration|Electricity|<Fuel>:
   description: Mean duration of an outage of a typical power plant generating
     electricity from <this fuel>
-  unit: "%"
+  unit: [day, hour]
 
 Inertia|Electricity|<Fuel>:
   description: Inertia provided to the system by a typical power plant

--- a/nomenclature/definitions/variable/technology/power-plant.yaml
+++ b/nomenclature/definitions/variable/technology/power-plant.yaml
@@ -53,14 +53,24 @@ Minimum Off Duration|Electricity|<Fuel>:
   unit: hour
 
 Forced Outage Rate|Electricity|<Fuel>:
-  description: Unavailability due to unexpected outages (e.g., failures)
+  description: Unavailability as a share relative to Maximum Active Power
+    due to unexpected outages (e.g., failures)
     of a typical power plant generating electricity from <this fuel>
-  unit: "%"
+  note: A value of 50 (%) means that the plant can generate at half of
+    maximum active power (~installed capacity) during an outage.
+    If the outage rate is lower than the level of minimum active power,
+    the plant has to be shut down for the duration of the outage.
+  unit: '%'
 
 Planned Outage Rate|Electricity|<Fuel>:
-  description: Unavailability due to planned outages (e.g., maintaince,
-    revision) of a typical power plant generating electricity from <this fuel>
-  unit: "%"
+  description: Unavailability as a share relative to Maximum Active Power
+    due to planned outages (e.g., maintaince, revision)
+    of a typical power plant generating electricity from <this fuel>
+  note: A value of 50 (%) means that the plant can generate at half of
+    maximum active power (~installed capacity) during an outage.
+    If the outage rate is lower than the level of minimum active power,
+    the plant has to be shut down for the duration of the outage.
+  unit: '%'
 
 Mean Outage Duration|Electricity|<Fuel>:
   description: Mean duration of an outage of a typical power plant generating


### PR DESCRIPTION
This PR implements the change agreed in #98. To provide some flexibility, the units allowed are days (for large thermal plants) and hours (for smaller units where outages are more quickly resolved).

closes #98