### PR TITLE
Implement a dictionary subclass `nomenclature.Definition`

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,5 +1,7 @@
 linters:
   flake8:
+    python: 3
+    max-line-length: 79
     fixer: true
 fixers:
   enable: true

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from collections.abc import Mapping
 import logging
 import yaml
 
@@ -25,6 +26,30 @@ CCS_TYPES = [
 ]
 
 
+class NomenclatureMapping(Mapping):
+    """A thin wrapper around a dictionary for nomenclature definitions"""
+    def __init__(self, name):
+        self._def = dict()
+        self._name = 'variables'
+
+    def __setitem__(self, key, value):
+        if key in self._def:
+            raise ValueError(f'Duplicate {self._name} key: {key}')
+        self._def[key] = value
+
+    def __getitem__(self, k):
+        return self._def[k]
+
+    def __iter__(self):
+        return iter(self._def)
+
+    def __len__(self):
+        return len(self._def)
+
+    def __repr__(self):
+        return self._def.__repr__()
+
+
 def _parse_yaml(path, file='**/*', ext='.yaml'):
     """Parse `file` in `path` (or all files in subfolders if `file='**/*'`)"""
     dct = {}
@@ -45,7 +70,7 @@ def _copy_dict(dct, description):
     return _dct
 
 
-variables = dict()
+variables = NomenclatureMapping('variable')
 """Dictionary of variables"""
 
 # read all variable definitions to auxiliary dictionary
@@ -93,16 +118,14 @@ for key, value in _variables.items():
                 if 'ccs' in attr and attr['ccs'] is True:
                     for sub, desc in CCS_TYPES:
                         _key_ccs = f'{_key}|{sub}'
-                        _description_ccs = f'{_description} {desc}'
-                        variables[_key_ccs] = _copy_dict(
-                            value, _description_ccs)
+                        _dict = _copy_dict(value, f'{_description} {desc}')
+                        variables[_key_ccs] = _dict
+
             has_tag = True
             break
 
     # if the variable does not contain a <tag>, move items to public dictionary
     if not has_tag:
-        if key in variables:
-            raise ValueError(f'Duplicate {key}')
         variables[key] = _variables[key]
 
 # remove auxiliary dictionary

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -26,7 +26,7 @@ CCS_TYPES = [
 ]
 
 
-class NomenclatureMapping(Mapping):
+class Definition(Mapping):
     """A thin wrapper around a dictionary for nomenclature definitions"""
 
     def __init__(self, name):
@@ -71,7 +71,7 @@ def _copy_dict(dct, description):
     return _dct
 
 
-variables = NomenclatureMapping('variable')
+variables = Definition('variable')
 """Dictionary of variables"""
 
 # read all variable definitions to auxiliary dictionary

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -29,8 +29,8 @@ CCS_TYPES = [
 class Definition(Mapping):
     """A thin wrapper around a dictionary for nomenclature definitions"""
 
-    def __init__(self, name):
-        self._def = dict()
+    def __init__(self, name, data=None):
+        self._def = data or dict()
         self._name = 'variables'
 
     def __setitem__(self, key, value):
@@ -132,11 +132,12 @@ for key, value in _variables.items():
 # remove auxiliary dictionary
 del _variables
 
-regions = _parse_yaml(DEF_PATH / 'region')
+regions = Definition('region', data=_parse_yaml(DEF_PATH / 'region'))
 """Dictionary of all regions"""
 
 
-countries = _parse_yaml(DEF_PATH / 'region', 'countries')
+countries = Definition('country',
+                       data=_parse_yaml(DEF_PATH / 'region', 'countries'))
 """Dictionary of countries"""
 
 
@@ -175,7 +176,7 @@ nuts_hierarchy = _create_nuts3_hierarchy()
 """Hierarchical dictionary of nuts region classification"""
 
 
-subannual = _parse_yaml(DEF_PATH / 'subannual')
+subannual = Definition('subannual', _parse_yaml(DEF_PATH / 'subannual'))
 """Dictionary of subannual timeslices"""
 
 

--- a/nomenclature/__init__.py
+++ b/nomenclature/__init__.py
@@ -28,6 +28,7 @@ CCS_TYPES = [
 
 class NomenclatureMapping(Mapping):
     """A thin wrapper around a dictionary for nomenclature definitions"""
+
     def __init__(self, name):
         self._def = dict()
         self._name = 'variables'

--- a/nomenclature/definitions/variable/technology/electrity-operation.yaml
+++ b/nomenclature/definitions/variable/technology/electrity-operation.yaml
@@ -366,68 +366,6 @@ Reserve|Electricity|Frequency Containment|Wind|OffShore:
 Reserve|Electricity|Frequency Containment|Energy Storage System:
    description: Frequency Containment Reserve available for energy storage systems, excl. hydro storage; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
    unit: MWh
-   
-# Inertia provided to the network per technologies
-# i.e. Inertia provided by aggregated committments of plants, storages and demand-side systems  
-  
-Inertia|Electricity|Biomass:
-   description: Inertia available for  Traditionnal Biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-   unit: s  
-  
-Inertia|Electricity|Biomass|Traditionnal:
-   description: Inertia available for  Traditionnal Biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-                biomass from local and pre-existing
-                resources mostly waste :domestic and agricultural waste, forest residues.
-   unit: s
-
-Inertia|Electricity|Biomass|New and imported:
-   description: Inertia available for New+Imported biomass power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-                biomass from dedicated energy crops and biomass imports.
-   unit: s
-
-Inertia|Electricity|Nuclear:
-   description: Inertia available for nuclear power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-   unit: s
-
-Inertia|Electricity|Gas:
-   description: Inertia available for Gas power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-   unit: s
-   
-Inertia|Electricity|Gas|OCGT:
-   description: Inertia available for Open Cycle Gas Turbine power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-   unit: s
-   
-Inertia|Electricity|Gas|CCGT:
-   description: Inertia available for Combined Cycle Gas Turbine power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-   unit: s
-
-Inertia|Electricity|Coal:
-   description: Inertia available for coal power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-   unit: s
-
-Inertia|Electricity|Lignite:
-   description: Inertia available for Lignite power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-   unit: s
-
-Inertia|Electricity|Oil:
-   description: Inertia available for Oil power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-   unit: s
-   
-Inertia|Electricity|Hydro|Reservoir:
-   description: Inertia available for "simple Hydro reservoir " units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-   unit: s
-   
-Inertia|Electricity|Hydro|Pumped Storage:
-   description: Inertia available for "Pumped Storage " units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-   unit: s
-   
-Inertia|Electricity|Hydro|Run of River:
-   description: Inertia available for "Run of River" units; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-   unit: s
-   
-Inertia|Electricity|Hydro|Ocean:
-   description: Inertia available for Ocean power plants; this amount is the maximum available for the grid operator considering the commitment decisions taken by the model
-   unit: s
 
 # Marginal costs associated to active power demand, reserves, CO2 emissions, inertia and flows in the grid
 


### PR DESCRIPTION
In a previous PR, I noticed that the check-for-duplicates implemented in the `variables` dictionary didn't catch key entered twice via a <Fuel> tag. This PR implements a subclass of a Python dictionary called `nomenclature.Definition` that checks for duplicates when adding key-value pairs (basically a mapping where a key can only be defined once and not updated).

The PR also removes the duplicate entries causing the problems.