### PR TITLE
Including regions from ehighway2050

### DIFF
--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -608,6 +608,44 @@ Sweden|Subgrid 89:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 88_SE
 
+# ehighway clusters United Kingdom
+
+United Kingdom|Subgrid 90:
+  definition: UKH11 + UKH12 + UKH14 + UKH15 + UKH16 + UKH17 + UKH21 + UKH23 + UKH24 + UKH25 + UKH31 + UKH32 + UKH34 + UKH35 + UKH36 + UKH37 + UKI31 + UKI32 + UKI33 + UKI34 + UKI41 + UKI42 + UKI43 + UKI44 + UKI45 + UKI51 + UKI52 + UKI53 + UKI54 + UKI61 + UKI62 + UKI63 + UKI71 + UKI72 + UKI73 + UKI74 + UKI75 + UKJ11 + UKJ12 + UKJ13 + UKJ14 + UKJ21 + UKJ22 + UKJ25 + UKJ26 + UKJ27 + UKJ28 + UKJ31 + UKJ32 + UKJ34 + UKJ35 + UKJ36 + UKJ37 + UKJ41 + UKJ43 + UKJ44 + UKJ45 + UKJ46
+  country: United Kingdom
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 90_UK
+
+United Kingdom|Subgrid 91:
+  definition: UKK11 + UKK12 + UKK13 + UKK14 + UKK15 + UKK23 + UKK24 + UKK25 + UKK30 + UKK41 + UKK42 + UKK43
+  country: United Kingdom
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 91_UK
+
+United Kingdom|Subgrid 92:
+  definition: UKD33 + UKD34 + UKD35 + UKD36 + UKD37 + UKD41 + UKD42 + UKD44 + UKD45 + UKD46 + UKD47 + UKD61 + UKD62 + UKD63 + UKD71 + UKD72 + UKD73 + UKD74 + UKE13 + UKE31 + UKE32 + UKE41 + UKE42 + UKE44 + UKE45 + UKF11 + UKF12 + UKF13 + UKF14 + UKF15 + UKF16 + UKF21 + UKF22 + UKF24 + UKF25 + UKF30 + UKG11 + UKG12 + UKG13 + UKG21 + UKG22 + UKG23 + UKG24 + UKG31 + UKG32 + UKG33 + UKG36 + UKG37 + UKG38 + UKG39 + UKL11 + UKL12 + UKL13 + UKL14 + UKL15 + UKL16 + UKL17 + UKL18 + UKL21 + UKL22 + UKL23 + UKL24
+  country: United Kingdom
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 92_UK
+
+United Kingdom|Subgrid 93:
+  definition: UKC11 + UKC12 + UKC13 + UKC14 + UKC21 + UKC22 + UKC23 + UKD11 + UKD12 + UKE11 + UKE12 + UKE21 + UKE22 + UKM73 + UKM75 + UKM78 + UKM91 + UKM92 + UKM93 + UKM94 + UKM95
+  country: United Kingdom
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 93_UK
+
+United Kingdom|Subgrid 94:
+  definition: UKM50 + UKM61 + UKM62 + UKM63 + UKM64 + UKM65 + UKM66 + UKM71 + UKM72 + UKM76 + UKM77 + UKM81 + UKM82 + UKM83 + UKM84
+  country: United Kingdom
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 94_UK
+
+United Kingdom|Subgrid 95:
+  definition: UKN06 + UKN07 + UKN08 + UKN09 + UKN0A + UKN0B + UKN0C + UKN0D + UKN0E + UKN0F + UKN0G
+  country: United Kingdom
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 95_UK
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -733,7 +733,7 @@ Germany|North Sea:
     plan4res: NSDE
 
 The Netherlands|North Sea:
-    definition: This 'virtual' region represents the offshore windpower of the netherlands in Norh Sea
+    definition: This 'virtual' region represents the offshore windpower of The Netherlands in Norh Sea
     country: The Netherlands
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 111_NS

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -522,6 +522,14 @@ Finland|Subgrid 75:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 75_FI
 
+# ehighway clusters Lithuania
+
+Lithuania|Subgrid 77:
+  definition: LT011 + LT021 + LT022 + LT023 + LT024 + LT025 + LT026 + LT027 + LT028 + LT029
+  country: Lithuania
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 77_LT
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -500,6 +500,14 @@ Albania|Subgrid 70:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 70_AL
 
+# ehighway clusters Estonia
+
+Estonia|Subgrid 73:
+  definition: EE001 + EE004 + EE008 + EE009 + EE00A
+  country: Estonia
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 73_EE
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -538,6 +538,50 @@ Latvia|Subgrid 78:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 78_LV
 
+# ehighway clusters Norway
+
+Norway|Subgrid 79:
+  definition: NO0A1 + NO092
+  country: Norway
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 79_NO
+
+Norway|Subgrid 80:
+  definition: NO082 + NO091
+  country: Norway
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 80_NO
+
+Norway|Subgrid 81:
+  definition: NO0A2
+  country: Norway
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 81_NO
+
+Norway|Subgrid 82:
+  definition: NO081 + NO020
+  country: Norway
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 82_NO
+
+Norway|Subgrid 83:
+  definition: NO060 + NO0A3
+  country: Norway
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 83_NO
+
+Norway|Subgrid 84:
+  definition: NO071
+  country: Norway
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 84_NO
+
+Norway|Subgrid 85:
+  definition: NO074
+  country: Norway
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 85_NO
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -654,6 +654,50 @@ Ireland|Subgrid 96:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 96_IE
 
+# ehighway clusters
+
+Russia|Subgrid 100:
+  definition: Region without NUTS3 but defined in ehighway2050
+  country: Russia
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 100_RU
+
+Ukrayne|Subgrid 100:
+  definition: Region without NUTS3 but defined in ehighway2050
+  country: Ukrayne
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 100_UA
+
+Turkey|Subgrid 101:
+  definition: Region without NUTS3 but defined in ehighway2050
+  country: Turkey
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 101_MI
+
+Morocco|Subgrid 102:
+  definition: Region without NUTS3 but defined in ehighway2050
+  country: Morocco
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 102_MA
+
+Algeria|Subgrid 103:
+  definition: Region without NUTS3 but defined in ehighway2050
+  country: Algeria
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 103_DZ
+
+Tunisia|Subgrid 104:
+  definition: Region without NUTS3 but defined in ehighway2050
+  country: Tunisia
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 104_TN
+
+Libya|Subgrid 105:
+  definition: Region without NUTS3 but defined in ehighway2050
+  country: Libya
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 105_LY
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy
@@ -701,7 +745,7 @@ United Kingdom|North Sea:
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 106_NS+107_NS+108_NS+109_NS
     plan4res: NSUK
-    
+
 # List of subregions in Norway
 # based on the regional electricity grid and key watersheds for hydropower generation
 Norway|Ostland:

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -746,6 +746,30 @@ United Kingdom|North Sea:
     ehighway2050: 106_NS+107_NS+108_NS+109_NS
     plan4res: NSUK
 
+United Kingdom|North Sea|Subgrid 106:
+    definition: this 'virtual' region holds the offshore windpower in norh sea near to the south of UK
+    country: United Kingdom
+    notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
+    ehighway2050: 106_NS
+
+United Kingdom|North Sea|Subgrid 107:
+    definition: this 'virtual' region holds the offshore windpower in norh sea near to the centre-south of UK
+    country: United Kingdom
+    notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
+    ehighway2050: 107_NS
+
+United Kingdom|North Sea|Subgrid 108:
+    definition: this 'virtual' region holds the offshore windpower in norh sea near to the centre-north of UK
+    country: United Kingdom
+    notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
+    ehighway2050: 108_NS
+
+United Kingdom|North Sea|Subgrid 109:
+    definition: this 'virtual' region holds the offshore windpower in norh sea near to the north of UK
+    country: United Kingdom
+    notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
+    ehighway2050: 109_NS
+
 # List of subregions in Norway
 # based on the regional electricity grid and key watersheds for hydropower generation
 Norway|Ostland:

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -788,6 +788,12 @@ Norway|North Sea|Subgrid 115:
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 115_NS
 
+Sweden|North Sea|Subgrid 116:
+    definition: This 'virtual' region holds the offshore windpower in norh sea near to Sweden
+    country: Sweden
+    notes: This region was defined and used in the ehighway2050 public datasets
+    ehighway2050: 116_NS
+
 # List of subregions in Norway
 # based on the regional electricity grid and key watersheds for hydropower generation
 Norway|Ostland:

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -646,6 +646,14 @@ United Kingdom|Subgrid 95:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 95_UK
 
+# ehighway clusters Ireland
+
+Ireland|Subgrid 96:
+  definition: IE041 + IE042 + IE051 + IE052 + IE053 + IE061 + IE062 + IE063
+  country: United Kingdom
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 96_IE
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -530,6 +530,14 @@ Lithuania|Subgrid 77:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 77_LT
 
+# ehighway clusters Latvia
+
+Latvia|Subgrid 78:
+  definition: LV003 + LV005 + LV006 + LV007 + LV008 + LV009
+  country: Latvia
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 78_LV
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -486,6 +486,14 @@ Greece|Subgrid 69:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 69_GR
 
+# ehighway clusters Albania
+
+Albania|Subgrid 70:
+  definition: AL011 + AL012 + AL013 + AL014 + AL015 + AL021 + AL022 + AL031 + AL032 + AL033 + AL034 + AL035
+  country: Albania
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 70_AL
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -582,6 +582,32 @@ Norway|Subgrid 85:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 85_NO
 
+# ehighway clusters Sweden
+
+Sweden|Subgrid 86:
+  definition: SE332
+  country: Sweden
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 86_SE
+
+Sweden|Subgrid 87:
+  definition: SE313 + SE322 + SE321 + SE331
+  country: Sweden
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 87_SE
+
+Sweden|Subgrid 88:
+  definition: SE110 + SE111 + SE113 + SE214 + SE121 + SE122 + SE123 + SE124 + SE125 + SE232 + SE311 + SE312
+  country: Sweden
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 88_SE
+
+Sweden|Subgrid 89:
+  definition: SE212 + SE221 + SE224 + SE231
+  country: Sweden
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 88_SE
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -15,6 +15,87 @@
 # describing France, Germany and Italy. For the rest of europe, country or regional aggregation is used in plan4res
 # they are defined as an aggregation of a list of NUTS3 regions
 
+# ehighway clusters Spain
+Spain|Subgrid 01:
+  definition: ES111 + ES112 + ES113 + ES114
+  country: Spain
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 01_ES
+
+Spain|Subgrid 02:
+  definition: ES120 + ES130 + ES413 + ES415 + ES419
+  country: Spain
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 02_ES
+
+Spain|Subgrid 03:
+  definition: ES411 + ES412 + ES414 + ES416 + ES417 + ES418 + ES424
+  country: Spain
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 03_ES
+
+Spain|Subgrid 04:
+  definition: ES211 +ES212 + ES213 + ES220 + ES230
+  country: Spain
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 04_ES
+
+Spain|Subgrid 05:
+  definition: ES241 + ES242 + ES243
+  country: Spain
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 05_ES
+
+Spain|Subgrid 06:
+  definition: ES511 + ES512 + ES513 + ES514
+  country: Spain
+  ehighway2050: 06_ES
+  note: This region was defined and used in the ehighway2050 public datasets
+
+Spain|Subgrid 07:
+  definition: ES300
+  country: Spain
+  ehighway2050: 07_ES
+  note: This region was defined and used in the ehighway2050 public datasets
+
+Spain|Subgrid 08:
+  definition: ES422 + ES425 + ES431 + ES432
+  country: Spain
+  ehighway2050: 08_ES
+  note: This region was defined and used in the ehighway2050 public datasets
+
+Spain|Subgrid 09:
+  definition: ES612 + ES615 + ES617 + ES618
+  country: Spain
+  ehighway2050: 09_ES
+  note: This region was defined and used in the ehighway2050 public datasets
+
+Spain|Subgrid 10:
+  definition: ES611 + ES613 + ES614 + ES616
+  country: Spain
+  ehighway2050: 10_ES
+  note: This region was defined and used in the ehighway2050 public datasets
+
+Spain|Subgrid 11:
+  definition: ES421 + ES423 + ES521 + ES522 + ES523 + ES620
+  country: Spain
+  ehighway2050: 11_ES
+  note: This region was defined and used in the ehighway2050 public datasets
+
+# ehighway clusters Portugal
+
+Portugal|Subgrid 12:
+  definition: PT111 + PT112 + PT119 + PT11A + PT11B + PT11C + PT11D + PT11E + PT16D + PT16E + PT16G + PT16H + PT16J
+  country: Portugal
+  ehighway2050: 12_PT
+  note: This region was defined and used in the ehighway2050 public datasets
+
+Portugal|Subgrid 13:
+  definition: PT150 + PT16B + PT16F + PT16I + PT170 + PT181 + PT184 + PT185 + PT186 + PT187
+  country: Portugal
+  ehighway2050: 13_PT
+  note: This region was defined and used in the ehighway2050 public datasets
+
 # ehighway clusters France
 
 France|Subgrid 14:
@@ -107,6 +188,30 @@ France|Subgrid 99:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 99_FR
 
+# ehighway clusters Belgium
+
+Belgium|Subgrid 28:
+  definition: BE100 + BE211 + BE212 + BE213 + BE223 + BE224 + BE225 + BE231 + BE232 + BE233 + BE234 + BE235 + BE236 + BE241 + BE251 + BE252 + BE253 + BE254 + BE255 + BE256 + BE257 + BE258 + BE310 + BE32A + BE32B + BE32C + BE32D + BE323 + BE328 + BE329 + BE331 + BE332 + BE334 + BE335 + BE336 + BE341 + BE342 + BE343 + BE344 + BE345 + BE351 + BE352 + BE353
+  country: Belgium
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 28_BE
+
+# ehighway clusters Luxembourg
+
+Luxembourg|Subgrid 29:
+  definition: LU00
+  country: Luxembourg
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 29_LU
+
+# ehighway clusters Netherlands
+
+Netherlands|Subgrid 30:
+  definition: NL111 + NL112 + NL113 + NL124 + NL125 + NL126 + NL131 + NL132 + NL133 + NL211 + NL212 + NL213 + NL221 + NL224 + NL225 + NL226 + NL230 + NL310 + NL321 + NL323 + NL324 + NL325 + NL327 + NL328 + NL329 + NL332 + NL333 + NL337 + NL33A + NL33B + NL33C + NL341 + NL342 + NL411 + NL412 + NL413 + NL414 + NL421 + NL422 + NL423
+  country: Netherlands
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 30_NL
+
 # ehighway clusters Germany
 Germany|Subgrid 31:
   definition: DE501 + DE502 + DE600 + DE911 + DE912 + DE913 + DE914 + DE916 + DE917 + DE918 + DE91A + DE91B + DE91C + DE922 + DE923 + DE925 + DE926 + DE927 + DE928 + DE929 + DE931 + DE932 + DE933 + DE934 + DE935 + DE936 + DE937 + DE938 + DE939 + DE93A + DE93B + DE941 + DE942 + DE943 + DE944 + DE945 + DE946 + DE947 + DE948 + DE949 + DE94A + DE94B + DE94C + DE94D + DE94E + DE94F + DE94G + DE94H + DEF01 + DEF02 + DEF03 + DEF04 + DEF05 + DEF06 + DEF07 + DEF08 + DEF09 + DEF0A + DEF0B + DEF0C + DEF0D + DEF0E + DEF0F + DEF0F
@@ -150,6 +255,102 @@ Germany|Subgrid 37:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 37_DE
 
+# ehighway clusters Denmark
+
+Denmark|Subgrid 38:
+  definition: DK011 + DK012 + DK013 + DK014 + DK021 + DK022 + DK031 + DK032 + DK041 + DK042 + DK050
+  country: Denmark
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 38_DK
+
+# ehighway clusters Czech Republic
+
+Czech Republic|Subgrid 39:
+  definition: CZ010 + CZ020 + CZ031 + CZ032 + CZ041 + CZ042 + CZ051 + CZ052
+  country: Czech Republic
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 39_CZ
+
+Czech Republic|Subgrid 40:
+  definition: CZ053 + CZ063 + CZ064 + CZ071 + CZ072 + CZ080
+  country: Czech Republic
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 40_CZ
+
+# ehighway clusters Poland
+
+Poland|Subgrid 41:
+  definition: PL711 + PL712 + PL713 + PL714 + PL715 + PL841 + PL842 + PL843 + PL911 + PL912 + PL913 + PL922 + PL923 + PL924 + PL925 + PL926
+  country: Poland
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 41_PL
+
+Poland|Subgrid 42:
+  definition: PL721 + PL722 + PL811 + PL812 + PL814 + PL815 + PL821 + PL822 + PL823 + PL824 + PL921
+  country: Poland
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 42_PL
+
+Poland|Subgrid 43:
+  definition: PL213 + PL214 + PL217 + PL218 + PL219 + PL21A + PL224 + PL225 + PL22A + PL22B + PL22C + PL227 + PL228 + PL229
+  country: Poland
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 43_PL
+
+Poland|Subgrid 44:
+  definition: PL411 + PL414 + PL415 + PL416 + PL417 + PL418 + PL424 + PL426 + PL427 + PL428 + PL431 + PL432 + PL514 + PL515 + PL516 + PL517 + PL518
+  country: Poland
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 44_PL
+
+Poland|Subgrid 45:
+  definition: PL613 + PL616 + PL617 + PL618 + PL619 + PL621 + PL622 + PL623 + PL633 + PL634 + PL636 + PL637 + PL638
+  country: Poland
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 45_PL
+
+# ehighway clusters Slovakia
+
+Slovakia|Subgrid 46:
+  definition: SK010 + SK021 + SK022 + SK023 + SK031 + SK032 + SK041 + SK042
+  country: Slovakia
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 46_SK
+
+# ehighway clusters Switzerland
+
+Switzerland|Subgrid 47:
+  definition: CH011 + CH013 + CH021 + CH022 + CH023 + CH024 + CH025 + CH031 + CH032 + CH033 + CH040 + CH051 + CH052 + CH053 + CH054 + CH057 + CH061 + CH063 + CH066
+  country: Switzerland
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 47_CH
+
+Switzerland|Subgrid 48:
+  definition: CH012 + CH056 + CH062 + CH064 + CH065 + CH070
+  country: Switzerland
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 48_CH
+
+# ehighway clusters Austria
+
+Austria|Subgrid 49:
+  definition: AT211 + AT212 + AT321 + AT322 + AT323 + AT331 + AT332 + AT333 + AT334 + AT335 + AT341 + AT342
+  country: Austria
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 49_AT
+
+Austria|Subgrid 50:
+  definition: AT213 + AT221 + AT222 + AT223 + AT224 + AT225 + AT226 + AT311 + AT312 + AT313 + AT314 + AT315
+  country: Austria
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 50_AT
+
+Austria|Subgrid 51:
+  definition: AT111 + AT112 + AT113 + AT121 + AT122 + AT123 + AT124 + AT125 + AT126 + AT127 + AT130
+  country: Austria
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 51_AT
+
 # ehighway clusters Italy
 Italy|Subgrid 52:
   definition: ITC11 + ITC12 + ITC13 + ITC14 + ITC15 + ITC16 + ITC17 + ITC18 + ITC20 + ITC31 + ITC32 + ITC33 + ITC34 + ITC41 + ITC42 + ITC43 + ITC44 + ITC46 + ITC47 + ITC48 + ITC49 + ITC4A + ITC4B + ITC4C + ITC4D + ITH10 + ITH20 + ITH31 + ITH32 + ITH33 + ITH34 + ITH35 + ITH36 + ITH37 + ITH41 + ITH42 + ITH43 + ITH44 + ITH51 + ITH52 + ITH53 + ITH54 + ITH55 + ITH56 + ITH57 + ITH58 + ITH59
@@ -187,73 +388,82 @@ Italy|Subgrid 98:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 98_IT
 
-# ehighway clusters Spain
-Spain|Subgrid 01:
-  definition: ES111 + ES112 + ES113 + ES114
-  country: Spain
-  note: This region was defined and used in the ehighway2050 public datasets
-  ehighway2050: 01_ES
+# ehighway clusters Slovenia
 
-Spain|Subgrid 02:
-  definition: ES120 + ES130 + ES413 + ES415 + ES419
-  country: Spain
+Slovenia|Subgrid 57:
+  definition: SI031 + SI032 + SI033 + SI034 + SI035 + SI036 + SI037 + SI038 + SI041 + SI042 + SI043 + SI044
+  country: Slovenia
   note: This region was defined and used in the ehighway2050 public datasets
-  ehighway2050: 02_ES
+  ehighway2050: 57_SI
 
-Spain|Subgrid 03:
-  definition: ES411 + ES412 + ES414 + ES416 + ES417 + ES418 + ES424
-  country: Spain
-  note: This region was defined and used in the ehighway2050 public datasets
-  ehighway2050: 03_ES
+# ehighway clusters Hungary
 
-Spain|Subgrid 04:
-  definition: ES211 +ES212 + ES213 + ES220 + ES230
-  country: Spain
+Hungary|Subgrid 58:
+  definition: HU110 + HU120 + HU211 + HU212 + HU213 + HU221 + HU222 + HU223 + HU231 + HU232 + HU233 + HU311 + HU312 + HU313 + HU321 + HU322 + HU323 + HU331 + HU332 + HU333
+  country: Hungary
   note: This region was defined and used in the ehighway2050 public datasets
-  ehighway2050: 04_ES
+  ehighway2050: 58_HU
 
-Spain|Subgrid 05:
-  definition: ES241 + ES242 + ES243
-  country: Spain
-  note: This region was defined and used in the ehighway2050 public datasets
-  ehighway2050: 05_ES
+# ehighway clusters Romania
 
-Spain|Subgrid 06:
-  definition: ES511 + ES512 + ES513 + ES514
-  country: Spain
-  ehighway2050: 06_ES
+Romania|Subgrid 59:
+  definition: RO111 + RO112 + RO113 + RO114 + RO115 + RO116 + RO121 + RO122 + RO123 + RO124 + RO125 + RO126 + RO421 + RO422 + RO423 + RO424
+  country: Romania
   note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 59_RO
 
-Spain|Subgrid 07:
-  definition: ES300
-  country: Spain
-  ehighway2050: 07_ES
+Romania|Subgrid 60:
+  definition: RO311 + RO313 + RO314 + RO316 + RO317 + RO321 + RO322 + RO411 + RO412 + RO413 + RO414 + RO415
+  country: Romania
   note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 60_RO
 
-Spain|Subgrid 08:
-  definition: ES422 + ES425 + ES431 + ES432
-  country: Spain
-  ehighway2050: 08_ES
+Romania|Subgrid 61:
+  definition: RO211 + RO212 + RO213 + RO214 + RO215 + RO216 + RO221 + RO222 + RO223 + RO224 + RO225 + RO226 + RO312 + RO315
+  country: Romania
   note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 61_RO
 
-Spain|Subgrid 09:
-  definition: ES612 + ES615 + ES617 + ES618
-  country: Spain
-  ehighway2050: 09_ES
-  note: This region was defined and used in the ehighway2050 public datasets
+# ehighway clusters Croatia
 
-Spain|Subgrid 10:
-  definition: ES611 + ES613 + ES614 + ES616
-  country: Spain
-  ehighway2050: 10_ES
+Croatia|Subgrid 62:
+  definition: HR021 + HR022 + HR023 + HR024 + HR025 + HR026 + HR027 + HR028 + HR031 + HR032 + HR033 + HR034 + HR035 + HR036 + HR050 + HR061 + HR062 + HR063 + HR064 + HR065
+  country: Croatia
   note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 62_HR
 
-Spain|Subgrid 11:
-  definition: ES421 + ES423 + ES521 + ES522 + ES523 + ES620
-  country: Spain
-  ehighway2050: 11_ES
+# ehighway clusters Bosnia and Herzegovina
+
+Bosnia and Herzegovina|Subgrid 63:
+  definition:
+  country: Bosnia and Herzegovina
   note: This region was defined and used in the ehighway2050 public datasets
-  
+  ehighway2050: 63_HR
+
+# ehighway clusters Montenegro
+
+Montenegro|Subgrid 64:
+  definition: ME000
+  country: Montenegro
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 64_ME
+
+# ehighway clusters Serbia
+
+Serbia|Subgrid 65:
+  definition: RS110 + RS121 + RS122 + RS123 + RS124 + RS125 + RS126 + RS127 + RS211 + RS212 + RS213 + RS214 + RS215 + RS216 + RS217 + RS218 + RS221 + RS222 + RS223 + RS224 + RS225 + RS226 + RS227 + RS228 + RS229
+  country: Serbia
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 65_RS
+
+# ehighway clusters Bulgaria
+
+Bulgaria|Subgrid 66:
+  definition: BG311 + BG312 + BG313 + BG314 + BG315 + BG321 + BG322 + BG323 + BG324 + BG325 + BG331 + BG332 + BG333 + BG334 + BG341 + BG342 + BG343 + BG344 + BG421 + BG422 + BG423 + BG424 + BG425 + BG411 + BG412 + BG413 + BG414 + BG415
+  country: Bulgaria
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 66_BG
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -719,68 +719,74 @@ Italy|Subgrid south:
 
 # ehighway north sea clusters
 Belgium|North Sea:
-    definition: this 'virtual' region holds the offshore windpower of belgium in norh sea
+    definition: This 'virtual' region holds the offshore windpower of belgium in norh sea
     country: Belgium
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 110_NS
     plan4res: NSBE
 
 Germany|North Sea:
-    definition: this 'virtual' region holds the offshore windpower of germany in norh sea
+    definition: This 'virtual' region holds the offshore windpower of germany in norh sea
     country: Germany
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 112_NS
     plan4res: NSDE
 
 The Netherlands|North Sea:
-    definition: this 'virtual' region holds the offshore windpower of the netherlands in norh sea
+    definition: This 'virtual' region holds the offshore windpower of the netherlands in norh sea
     country: The Netherlands
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 111_NS
     plan4res: NSNL
 
 United Kingdom|North Sea:
-    definition: this 'virtual' region holds the offshore windpower of the UK in norh sea
+    definition: This 'virtual' region holds the offshore windpower of the UK in norh sea
     country: United Kingdom
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 106_NS+107_NS+108_NS+109_NS
     plan4res: NSUK
 
 United Kingdom|North Sea|Subgrid 106:
-    definition: this 'virtual' region holds the offshore windpower in norh sea near to the south of UK
+    definition: This 'virtual' region holds the offshore windpower in norh sea near to the south of UK
     country: United Kingdom
-    notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
+    notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 106_NS
 
 United Kingdom|North Sea|Subgrid 107:
-    definition: this 'virtual' region holds the offshore windpower in norh sea near to the centre-south of UK
+    definition: This 'virtual' region holds the offshore windpower in norh sea near to the centre-south of UK
     country: United Kingdom
-    notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
+    notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 107_NS
 
 United Kingdom|North Sea|Subgrid 108:
-    definition: this 'virtual' region holds the offshore windpower in norh sea near to the centre-north of UK
+    definition: This 'virtual' region holds the offshore windpower in norh sea near to the centre-north of UK
     country: United Kingdom
-    notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
+    notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 108_NS
 
 United Kingdom|North Sea|Subgrid 109:
-    definition: this 'virtual' region holds the offshore windpower in norh sea near to the north of UK
+    definition: This 'virtual' region holds the offshore windpower in norh sea near to the north of UK
     country: United Kingdom
-    notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
+    notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 109_NS
 
 Denmark|North Sea|Subgrid 113:
-    definition: this 'virtual' region holds the offshore windpower in norh sea near to Denmark
+    definition: This 'virtual' region holds the offshore windpower in norh sea near to Denmark
     country: Denmark
-    notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
+    notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 113_NS
 
 Denmark|North Sea|Subgrid 114:
-    definition: this 'virtual' region holds the offshore windpower in norh sea near to Denmark
+    definition: This 'virtual' region holds the offshore windpower in norh sea near to Denmark
     country: Denmark
-    notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
+    notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 114_NS
+
+Norway|North Sea|Subgrid 115:
+    definition: This 'virtual' region holds the offshore windpower in norh sea near to Norway
+    country: Norway
+    notes: This region was defined and used in the ehighway2050 public datasets
+    ehighway2050: 115_NS
 
 # List of subregions in Norway
 # based on the regional electricity grid and key watersheds for hydropower generation

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -657,7 +657,7 @@ Ireland|Subgrid 96:
 # ehighway clusters
 
 Russia|Subgrid 100:
-  definition: Region without NUTS3 but defined in ehighway2050
+  definition: Russia West of the Urals
   country: Russia
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 100_RU

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -472,6 +472,20 @@ North Macedonia|Subgrid 67:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 67_MK
 
+# ehighway clusters Greece
+
+Greece|Subgrid 68:
+  definition: EL511 + EL512 + EL513 + EL514 + EL515 + EL521 + EL522 + EL523 + EL524 + EL525 + EL526 + EL527 + EL531 + EL532 + EL533 + EL541 + EL542 + EL543 + EL611 + EL612 + EL622 + EL631
+  country: Greece
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 68_GR
+
+Greece|Subgrid 69:
+  definition: EL301 + EL302 + EL303 + EL304 + EL305 + EL306 + EL307 + EL411 + EL412 + EL413 + EL421 + EL422 + EL431 + EL432 + EL433 + EL434 + EL621 + EL622 + EL623 + EL632 + EL633 + EL641 + EL642 + EL643 + EL644 + EL645 + EL651 + EL652 + EL653
+  country: Greece
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 69_GR
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -258,10 +258,16 @@ Germany|Subgrid 37:
 # ehighway clusters Denmark
 
 Denmark|Subgrid 38:
-  definition: DK011 + DK012 + DK013 + DK014 + DK021 + DK022 + DK031 + DK032 + DK041 + DK042 + DK050
+  definition: DK031 + DK032 + DK041 + DK042 + DK050
   country: Denmark
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 38_DK
+
+Denmark|Subgrid 72:
+  definition: DK011 + DK012 + DK013 + DK014 + DK021 + DK022
+  country: Denmark
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 72_DK
 
 # ehighway clusters Czech Republic
 

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -662,38 +662,38 @@ Russia|Subgrid 100:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 100_RU
 
-Ukrayne|Subgrid 100:
-  definition: Region without NUTS3 but defined in ehighway2050
+Ukraine|Subgrid 100:
+  definition: Western Ukraine
   country: Ukrayne
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 100_UA
 
 Turkey|Subgrid 101:
-  definition: Region without NUTS3 but defined in ehighway2050
+  definition: Marmara Region of Turkey
   country: Turkey
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 101_MI
 
 Morocco|Subgrid 102:
-  definition: Region without NUTS3 but defined in ehighway2050
+  definition: Northern Region of Morocco
   country: Morocco
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 102_MA
 
 Algeria|Subgrid 103:
-  definition: Region without NUTS3 but defined in ehighway2050
+  definition: Northern Region of Algeria
   country: Algeria
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 103_DZ
 
 Tunisia|Subgrid 104:
-  definition: Region without NUTS3 but defined in ehighway2050
+  definition: Northern Region of Tunisia
   country: Tunisia
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 104_TN
 
 Libya|Subgrid 105:
-  definition: Region without NUTS3 but defined in ehighway2050
+  definition: Northern Region of Libya
   country: Libya
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 105_LY

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -719,7 +719,7 @@ Italy|Subgrid south:
 
 # ehighway north sea clusters
 Belgium|North Sea:
-    definition: This 'virtual' region holds the offshore windpower of belgium in norh sea
+    definition: This 'virtual' region represents offshore wind generation of Belgium in the North Sea
     country: Belgium
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 110_NS

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -770,6 +770,18 @@ United Kingdom|North Sea|Subgrid 109:
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 109_NS
 
+Denmark|North Sea|Subgrid 113:
+    definition: this 'virtual' region holds the offshore windpower in norh sea near to Denmark
+    country: Denmark
+    notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
+    ehighway2050: 113_NS
+
+Denmark|North Sea|Subgrid 114:
+    definition: this 'virtual' region holds the offshore windpower in norh sea near to Denmark
+    country: Denmark
+    notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
+    ehighway2050: 114_NS
+
 # List of subregions in Norway
 # based on the regional electricity grid and key watersheds for hydropower generation
 Norway|Ostland:

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -464,6 +464,14 @@ Bulgaria|Subgrid 66:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 66_BG
 
+# ehighway clusters North macedonia
+
+North Macedonia|Subgrid 67:
+  definition: MK001 + MK002 + MK003 + MK004 + MK005 + MK006 + MK007 + MK008
+  country: North Macedonia
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 67_MK
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -726,7 +726,7 @@ Belgium|North Sea:
     plan4res: NSBE
 
 Germany|North Sea:
-    definition: This 'virtual' region represents the offshore windpower of germany in the Norh Sea
+    definition: This 'virtual' region represents the offshore windpower of Germany in the North Sea
     country: Germany
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 112_NS

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -726,70 +726,70 @@ Belgium|North Sea:
     plan4res: NSBE
 
 Germany|North Sea:
-    definition: This 'virtual' region holds the offshore windpower of germany in norh sea
+    definition: This 'virtual' region represents the offshore windpower of germany in the Norh Sea
     country: Germany
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 112_NS
     plan4res: NSDE
 
 The Netherlands|North Sea:
-    definition: This 'virtual' region holds the offshore windpower of the netherlands in norh sea
+    definition: This 'virtual' region represents the offshore windpower of the netherlands in Norh Sea
     country: The Netherlands
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 111_NS
     plan4res: NSNL
 
 United Kingdom|North Sea:
-    definition: This 'virtual' region holds the offshore windpower of the UK in norh sea
+    definition: This 'virtual' region represents the offshore windpower of the UK in Norh Sea
     country: United Kingdom
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 106_NS+107_NS+108_NS+109_NS
     plan4res: NSUK
 
 United Kingdom|North Sea|Subgrid 106:
-    definition: This 'virtual' region holds the offshore windpower in norh sea near to the south of UK
+    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to the south of UK
     country: United Kingdom
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 106_NS
 
 United Kingdom|North Sea|Subgrid 107:
-    definition: This 'virtual' region holds the offshore windpower in norh sea near to the centre-south of UK
+    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to the centre-south of UK
     country: United Kingdom
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 107_NS
 
 United Kingdom|North Sea|Subgrid 108:
-    definition: This 'virtual' region holds the offshore windpower in norh sea near to the centre-north of UK
+    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to the centre-north of UK
     country: United Kingdom
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 108_NS
 
 United Kingdom|North Sea|Subgrid 109:
-    definition: This 'virtual' region holds the offshore windpower in norh sea near to the north of UK
+    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to the north of UK
     country: United Kingdom
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 109_NS
 
 Denmark|North Sea|Subgrid 113:
-    definition: This 'virtual' region holds the offshore windpower in norh sea near to Denmark
+    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to Denmark
     country: Denmark
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 113_NS
 
 Denmark|North Sea|Subgrid 114:
-    definition: This 'virtual' region holds the offshore windpower in norh sea near to Denmark
+    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to Denmark
     country: Denmark
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 114_NS
 
 Norway|North Sea|Subgrid 115:
-    definition: This 'virtual' region holds the offshore windpower in norh sea near to Norway
+    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to Norway
     country: Norway
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 115_NS
 
 Sweden|North Sea|Subgrid 116:
-    definition: This 'virtual' region holds the offshore windpower in norh sea near to Sweden
+    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to Sweden
     country: Sweden
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 116_NS

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -508,6 +508,20 @@ Estonia|Subgrid 73:
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 73_EE
 
+# ehighway clusters Finland
+
+Finland|Subgrid 74:
+  definition: FI1D7 + FI1D8 + FI1D9
+  country: Finland
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 74_FI
+
+Finland|Subgrid 75:
+  definition: FI193 + FI194 + FI195 + FI196 + FI197 +FI1B1 + FI1C1 + FI1C2 + FI1C3 + FI1C4 + FI1C5 + FI1D1 + FI1D2 + FI1D3 + FI1D5 + FI200
+  country: Finland
+  note: This region was defined and used in the ehighway2050 public datasets
+  ehighway2050: 75_FI
+
 # Aggregation of ehighway clusters in larger subcountry regions
 
 # Aggregation of ehighway clusters for Italy

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -717,7 +717,7 @@ Italy|Subgrid south:
   ehighway2050: 54_IT + 55_IT + 56_IT + 98_IT
   plan4res: ITS
 
-# ehighway north sea clusters
+# ehighway North Sea clusters
 Belgium|North Sea:
     definition: This 'virtual' region represents offshore wind generation of Belgium in the North Sea
     country: Belgium
@@ -733,63 +733,63 @@ Germany|North Sea:
     plan4res: NSDE
 
 The Netherlands|North Sea:
-    definition: This 'virtual' region represents the offshore windpower of The Netherlands in Norh Sea
+    definition: This 'virtual' region represents the offshore windpower of The Netherlands in North Sea
     country: The Netherlands
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 111_NS
     plan4res: NSNL
 
 United Kingdom|North Sea:
-    definition: This 'virtual' region represents the offshore windpower of the UK in Norh Sea
+    definition: This 'virtual' region represents the offshore windpower of the UK in North Sea
     country: United Kingdom
     notes: This region was defined and used in the plan4res public datasets, it is built as aggregation of ehighway2050 regions
     ehighway2050: 106_NS+107_NS+108_NS+109_NS
     plan4res: NSUK
 
 United Kingdom|North Sea|Subgrid 106:
-    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to the south of UK
+    definition: This 'virtual' region represents the offshore windpower in the North Sea near to the south of UK
     country: United Kingdom
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 106_NS
 
 United Kingdom|North Sea|Subgrid 107:
-    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to the centre-south of UK
+    definition: This 'virtual' region represents the offshore windpower in the North Sea near to the centre-south of UK
     country: United Kingdom
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 107_NS
 
 United Kingdom|North Sea|Subgrid 108:
-    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to the centre-north of UK
+    definition: This 'virtual' region represents the offshore windpower in the North Sea near to the centre-north of UK
     country: United Kingdom
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 108_NS
 
 United Kingdom|North Sea|Subgrid 109:
-    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to the north of UK
+    definition: This 'virtual' region represents the offshore windpower in the North Sea near to the north of UK
     country: United Kingdom
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 109_NS
 
 Denmark|North Sea|Subgrid 113:
-    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to Denmark
+    definition: This 'virtual' region represents the offshore windpower in the North Sea near to Denmark
     country: Denmark
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 113_NS
 
 Denmark|North Sea|Subgrid 114:
-    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to Denmark
+    definition: This 'virtual' region represents the offshore windpower in the North Sea near to Denmark
     country: Denmark
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 114_NS
 
 Norway|North Sea|Subgrid 115:
-    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to Norway
+    definition: This 'virtual' region represents the offshore windpower in the North Sea near to Norway
     country: Norway
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 115_NS
 
 Sweden|North Sea|Subgrid 116:
-    definition: This 'virtual' region represents the offshore windpower in the Norh Sea near to Sweden
+    definition: This 'virtual' region represents the offshore windpower in the North Sea near to Sweden
     country: Sweden
     notes: This region was defined and used in the ehighway2050 public datasets
     ehighway2050: 116_NS

--- a/nomenclature/definitions/region/subcountries.yaml
+++ b/nomenclature/definitions/region/subcountries.yaml
@@ -664,7 +664,7 @@ Russia|Subgrid 100:
 
 Ukraine|Subgrid 100:
   definition: Western Ukraine
-  country: Ukrayne
+  country: Ukraine
   note: This region was defined and used in the ehighway2050 public datasets
   ehighway2050: 100_UA
 


### PR DESCRIPTION
This PR adds the regions that were defined and used in the ehighway2050 public datasets but not included in Nomenclature.