### PR TITLE
Adding "iH2" to industry_types.yaml

### DIFF
--- a/nomenclature/definitions/variable/industry_types.yaml
+++ b/nomenclature/definitions/variable/industry_types.yaml
@@ -63,3 +63,6 @@
 
   iELCT:
     description: 'Production of electricity by Geothermal'
+
+  iH2:
+    description: 'Hydrogen'


### PR DESCRIPTION
This PR adds the industry "iH2" that represents the industry of hydrogen.

closes #117 