### PR TITLE
Add R5 and World region

### DIFF
--- a/nomenclature/definitions/region/common.yaml
+++ b/nomenclature/definitions/region/common.yaml
@@ -1,0 +1,4 @@
+# List of common regions
+
+World:
+  definition:

--- a/nomenclature/definitions/region/global-regions.yaml
+++ b/nomenclature/definitions/region/global-regions.yaml
@@ -1,0 +1,66 @@
+# List of global aggregate regions (e.g., continents)
+
+# The R5 definitions are taken from the call for submissions
+# to the AR6 WG3 scenario ensemble
+# https://data.ene.iiasa.ac.at/ar6-scenario-submission/#/about
+
+OECD & EU (R5):
+  definition: OECD 90 and EU member states and candidates
+  ar6: R5OECD90+EU
+  ssp: R5.2OECD
+  countries: Albania, Australia, Austria, Belgium, Bosnia and Herzegovina, Bulgaria,
+    Canada, Croatia, Cyprus, Czech Republic, Denmark, Estonia, Finland, France, Germany,
+    Greece, Guam, Hungary, Iceland, Ireland, Italy, Japan, Latvia, Lithuania,
+    Luxembourg, Malta, Montenegro, Netherlands, New Zealand, North Macedonia, Norway,
+    Poland, Portugal, Puerto Rico, Romania, Serbia, Slovakia, Slovenia, Spain, Sweden,
+    Switzerland, Turkey, United Kingdom, United States of America
+
+Reforming Economies (R5):
+  definition: Countries from the Reforming Ecomonies of the Former Soviet Union
+  ar6: R5REF
+  ssp: R5.2REF
+  countries: Armenia, Azerbaijan, Belarus, Georgia, Kazakhstan, Kyrgyzstan,
+    Republic of Moldova, Russia, Tajikistan, Turkmenistan, Ukraine, Uzbekistan
+
+Asia (R5):
+  definition: The region includes Asian countries with the exception
+    of the Middle East, Japan and Former Soviet Union states.
+  ar6: R5ASIA
+  ssp: R5.2ASIA
+  countries: Afghanistan, Bangladesh, Bhutan, Brunei Darussalam, Cambodia,
+    China (incl. Hong Kong and Macao, excl. Taiwan), Republic of Korea, Fiji,
+    French Polynesia, India, Indonesia, Lao People's Democratic Republic, Malaysia,
+    Maldives, Micronesia (Fed. States of), Mongolia, Myanmar, Nepal, New Caledonia,
+    Pakistan, Papua New Guinea, Philippines, Republic of Korea, Samoa, Singapore,
+    Solomon Islands, Sri Lanka, Taiwan, Thailand, Timor-Leste, Vanuatu, Vietnam
+
+Middle East & Africa (R5):
+  definition: Countries of the Middle East and Africa.
+  ar6: R5MAF
+  ssp: R5.2MAF
+  countries: Algeria, Angola, Bahrain, Benin, Botswana, Burkina Faso, Burundi, Cameroon,
+    Cape Verde, Central African Republic, Chad, Comoros, Congo, Côte d`Ivoire,
+    Democratic Republic of the Congo, Djibouti, Egypt, Equatorial Guinea, Eritrea,
+    Ethiopia, Gabon, Gambia, Ghana, Guinea, Guinea-Bissau, Iran, Iraq, Israel, Jordan,
+    Kenya, Kuwait, Lebanon, Lesotho, Liberia, Libyan Arab Jamahiriya, Madagascar,
+    Malawi, Mali, Mauritania, Mauritius, Mayotte, Morocco, Mozambique, Namibia, Niger,
+    Nigeria, Occupied Palestinian Territory, Oman, Qatar, Rwanda, Réunion, Saudi Arabia,
+    Senegal, Sierra Leone, Somalia, South Africa, South Sudan, Sudan, Swaziland,
+    Syrian Arab Republic, Togo, Tunisia, Uganda, United Arab Emirates,
+    United Republic of Tanzania, Western Sahara, Yemen, Zambia, Zimbabwe
+
+Latin America (R5):
+  definition: Latin American countries.
+  ar6: R5LAM
+  ssp: R5.2LAM
+  countries: Argentina, Aruba, Bahamas, Barbados, Belize, Bolivia, Brazil, Chile,
+    Colombia, Costa Rica, Cuba, Dominican Republic, Ecuador, El Salvador, French Guiana,
+    Grenada, Guadeloupe, Guatemala, Guyana, Haiti, Honduras, Jamaica, Martinique,
+    Mexico, Nicaragua, Panama, Paraguay, Peru, Suriname, Trinidad and Tobago,
+    United States Virgin Islands, Uruguay, Venezuela
+
+Other (R5):
+  definition: Rest of the World - to be used only if a match with the 5 SSP regions
+    can otherwise not be achieved.
+  ar6: R5ROWO
+  ssp:


### PR DESCRIPTION
This PR adds "World" and the AR6-version of the R5 regions. Implements part of the discussion in #119.

The PR uses more human-readable region names, but adds the AR6 and SSP spellings for clarity.